### PR TITLE
Add reporting views and policy-based authorization

### DIFF
--- a/AccountingSystem/Authorization/PermissionHandler.cs
+++ b/AccountingSystem/Authorization/PermissionHandler.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using AccountingSystem.Data;
+using AccountingSystem.Models;
+
+namespace AccountingSystem.Authorization
+{
+    public class PermissionHandler : AuthorizationHandler<PermissionRequirement>
+    {
+        private readonly UserManager<User> _userManager;
+        private readonly ApplicationDbContext _context;
+
+        public PermissionHandler(UserManager<User> userManager, ApplicationDbContext context)
+        {
+            _userManager = userManager;
+            _context = context;
+        }
+
+        protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, PermissionRequirement requirement)
+        {
+            var user = await _userManager.GetUserAsync(context.User);
+            if (user == null || !user.IsActive)
+            {
+                return;
+            }
+
+            var hasPermission = await _context.UserPermissions
+                .Include(up => up.Permission)
+                .AnyAsync(up => up.UserId == user.Id && up.Permission.Name == requirement.Permission && up.IsGranted);
+
+            if (hasPermission)
+            {
+                context.Succeed(requirement);
+            }
+        }
+    }
+}

--- a/AccountingSystem/Authorization/PermissionPolicyProvider.cs
+++ b/AccountingSystem/Authorization/PermissionPolicyProvider.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Options;
+
+namespace AccountingSystem.Authorization
+{
+    public class PermissionPolicyProvider : IAuthorizationPolicyProvider
+    {
+        public DefaultAuthorizationPolicyProvider FallbackPolicyProvider { get; }
+
+        public PermissionPolicyProvider(IOptions<AuthorizationOptions> options)
+        {
+            FallbackPolicyProvider = new DefaultAuthorizationPolicyProvider(options);
+        }
+
+        public Task<AuthorizationPolicy?> GetPolicyAsync(string policyName)
+        {
+            var policy = new AuthorizationPolicyBuilder();
+            policy.AddRequirements(new PermissionRequirement(policyName));
+            return Task.FromResult<AuthorizationPolicy?>(policy.Build());
+        }
+
+        public Task<AuthorizationPolicy> GetDefaultPolicyAsync() => FallbackPolicyProvider.GetDefaultPolicyAsync();
+
+        public Task<AuthorizationPolicy?> GetFallbackPolicyAsync() => FallbackPolicyProvider.GetFallbackPolicyAsync();
+    }
+}

--- a/AccountingSystem/Authorization/PermissionRequirement.cs
+++ b/AccountingSystem/Authorization/PermissionRequirement.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace AccountingSystem.Authorization
+{
+    public class PermissionRequirement : IAuthorizationRequirement
+    {
+        public string Permission { get; }
+
+        public PermissionRequirement(string permission)
+        {
+            Permission = permission;
+        }
+    }
+}

--- a/AccountingSystem/Controllers/AccountsController.cs
+++ b/AccountingSystem/Controllers/AccountsController.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace AccountingSystem.Controllers
 {
-    [Authorize]
+    [Authorize(Policy = "accounts.view")]
     public class AccountsController : Controller
     {
         private readonly ApplicationDbContext _context;
@@ -86,6 +86,7 @@ namespace AccountingSystem.Controllers
         }
 
         // GET: Accounts/Create
+        [Authorize(Policy = "accounts.create")]
         public async Task<IActionResult> Create()
         {
             var viewModel = new CreateAccountViewModel();
@@ -96,6 +97,7 @@ namespace AccountingSystem.Controllers
         // POST: Accounts/Create
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Policy = "accounts.create")]
         public async Task<IActionResult> Create(CreateAccountViewModel model)
         {
             if (ModelState.IsValid)

--- a/AccountingSystem/Controllers/BranchesController.cs
+++ b/AccountingSystem/Controllers/BranchesController.cs
@@ -7,7 +7,7 @@ using AccountingSystem.ViewModels;
 
 namespace AccountingSystem.Controllers
 {
-    [Authorize]
+    [Authorize(Policy = "branches.view")]
     public class BranchesController : Controller
     {
         private readonly ApplicationDbContext _context;
@@ -90,6 +90,7 @@ namespace AccountingSystem.Controllers
             return View(viewModel);
         }
 
+        [Authorize(Policy = "branches.create")]
         public IActionResult Create()
         {
             return View(new CreateBranchViewModel());
@@ -97,6 +98,7 @@ namespace AccountingSystem.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Policy = "branches.create")]
         public async Task<IActionResult> Create(CreateBranchViewModel model)
         {
             if (ModelState.IsValid)
@@ -130,6 +132,7 @@ namespace AccountingSystem.Controllers
             return View(model);
         }
 
+        [Authorize(Policy = "branches.edit")]
         public async Task<IActionResult> Edit(int id)
         {
             var branch = await _context.Branches.FindAsync(id);
@@ -156,6 +159,7 @@ namespace AccountingSystem.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Policy = "branches.edit")]
         public async Task<IActionResult> Edit(EditBranchViewModel model)
         {
             if (ModelState.IsValid)
@@ -194,6 +198,7 @@ namespace AccountingSystem.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Policy = "branches.delete")]
         public async Task<IActionResult> Delete(int id)
         {
             var branch = await _context.Branches
@@ -222,6 +227,7 @@ namespace AccountingSystem.Controllers
             return RedirectToAction(nameof(Index));
         }
 
+        [Authorize(Policy = "branches.edit")]
         public async Task<IActionResult> ManageUsers(int id)
         {
             var branch = await _context.Branches
@@ -254,6 +260,7 @@ namespace AccountingSystem.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Policy = "branches.edit")]
         public async Task<IActionResult> ManageUsers(ManageBranchUsersViewModel model)
         {
             var branch = await _context.Branches

--- a/AccountingSystem/Controllers/CostCentersController.cs
+++ b/AccountingSystem/Controllers/CostCentersController.cs
@@ -7,7 +7,7 @@ using AccountingSystem.ViewModels;
 
 namespace AccountingSystem.Controllers
 {
-    [Authorize]
+    [Authorize(Policy = "costcenters.view")]
     public class CostCentersController : Controller
     {
         private readonly ApplicationDbContext _context;
@@ -85,6 +85,7 @@ namespace AccountingSystem.Controllers
             return View(viewModel);
         }
 
+        [Authorize(Policy = "costcenters.create")]
         public IActionResult Create()
         {
             return View(new CreateCostCenterViewModel());
@@ -92,6 +93,7 @@ namespace AccountingSystem.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Policy = "costcenters.create")]
         public async Task<IActionResult> Create(CreateCostCenterViewModel model)
         {
             if (ModelState.IsValid)
@@ -122,6 +124,7 @@ namespace AccountingSystem.Controllers
             return View(model);
         }
 
+        [Authorize(Policy = "costcenters.edit")]
         public async Task<IActionResult> Edit(int id)
         {
             var costCenter = await _context.CostCenters.FindAsync(id);
@@ -145,6 +148,7 @@ namespace AccountingSystem.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Policy = "costcenters.edit")]
         public async Task<IActionResult> Edit(EditCostCenterViewModel model)
         {
             if (ModelState.IsValid)
@@ -180,6 +184,7 @@ namespace AccountingSystem.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Policy = "costcenters.delete")]
         public async Task<IActionResult> Delete(int id)
         {
             var costCenter = await _context.CostCenters

--- a/AccountingSystem/Controllers/DashboardController.cs
+++ b/AccountingSystem/Controllers/DashboardController.cs
@@ -7,7 +7,7 @@ using AccountingSystem.ViewModels;
 
 namespace AccountingSystem.Controllers
 {
-    [Authorize]
+    [Authorize(Policy = "dashboard.view")]
     public class DashboardController : Controller
     {
         private readonly ApplicationDbContext _context;

--- a/AccountingSystem/Controllers/UsersController.cs
+++ b/AccountingSystem/Controllers/UsersController.cs
@@ -1,0 +1,101 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using AccountingSystem.Data;
+using AccountingSystem.Models;
+using AccountingSystem.ViewModels;
+using System.Linq;
+
+namespace AccountingSystem.Controllers
+{
+    [Authorize(Policy = "users.view")]
+    public class UsersController : Controller
+    {
+        private readonly UserManager<User> _userManager;
+        private readonly ApplicationDbContext _context;
+
+        public UsersController(UserManager<User> userManager, ApplicationDbContext context)
+        {
+            _userManager = userManager;
+            _context = context;
+        }
+
+        public async Task<IActionResult> Index()
+        {
+            var users = await _userManager.Users
+                .Select(u => new UserListViewModel
+                {
+                    Id = u.Id,
+                    Email = u.Email ?? string.Empty,
+                    FullName = u.FullName ?? string.Empty,
+                    IsActive = u.IsActive
+                }).ToListAsync();
+
+            return View(users);
+        }
+
+        [Authorize(Policy = "users.edit")]
+        public async Task<IActionResult> ManagePermissions(string id)
+        {
+            if (string.IsNullOrEmpty(id)) return NotFound();
+
+            var user = await _userManager.FindByIdAsync(id);
+            if (user == null) return NotFound();
+
+            var permissions = await _context.Permissions
+                .OrderBy(p => p.Category)
+                .ThenBy(p => p.DisplayName)
+                .ToListAsync();
+
+            var userPermissions = await _context.UserPermissions
+                .Where(up => up.UserId == id && up.IsGranted)
+                .ToListAsync();
+
+            var model = new ManageUserPermissionsViewModel
+            {
+                UserId = user.Id,
+                UserName = user.FullName ?? user.Email ?? string.Empty,
+                Permissions = permissions.Select(p => new PermissionSelectionViewModel
+                {
+                    PermissionId = p.Id,
+                    DisplayName = p.DisplayName,
+                    Category = p.Category,
+                    IsGranted = userPermissions.Any(up => up.PermissionId == p.Id)
+                }).ToList()
+            };
+
+            return View(model);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        [Authorize(Policy = "users.edit")]
+        public async Task<IActionResult> ManagePermissions(ManageUserPermissionsViewModel model)
+        {
+            var user = await _userManager.FindByIdAsync(model.UserId);
+            if (user == null) return NotFound();
+
+            var existing = await _context.UserPermissions
+                .Where(up => up.UserId == model.UserId)
+                .ToListAsync();
+
+            _context.UserPermissions.RemoveRange(existing);
+
+            foreach (var perm in model.Permissions.Where(p => p.IsGranted))
+            {
+                _context.UserPermissions.Add(new UserPermission
+                {
+                    UserId = model.UserId,
+                    PermissionId = perm.PermissionId,
+                    IsGranted = true,
+                    CreatedAt = DateTime.UtcNow
+                });
+            }
+
+            await _context.SaveChangesAsync();
+            TempData["SuccessMessage"] = "تم تحديث صلاحيات المستخدم بنجاح.";
+            return RedirectToAction(nameof(Index));
+        }
+    }
+}

--- a/AccountingSystem/Program.cs
+++ b/AccountingSystem/Program.cs
@@ -1,5 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Authorization;
+using AccountingSystem.Authorization;
 using AccountingSystem.Data;
 using AccountingSystem.Models;
 
@@ -37,6 +39,8 @@ builder.Services.ConfigureApplicationCookie(options =>
 });
 
 builder.Services.AddControllersWithViews();
+builder.Services.AddSingleton<IAuthorizationPolicyProvider, PermissionPolicyProvider>();
+builder.Services.AddScoped<IAuthorizationHandler, PermissionHandler>();
 
 var app = builder.Build();
 

--- a/AccountingSystem/ViewModels/SimpleViewModels.cs
+++ b/AccountingSystem/ViewModels/SimpleViewModels.cs
@@ -197,6 +197,33 @@ namespace AccountingSystem.ViewModels
         public decimal RunningBalance { get; set; }
     }
 
+    public class GeneralLedgerViewModel
+    {
+        public int? AccountId { get; set; }
+        public DateTime FromDate { get; set; } = DateTime.Now.AddMonths(-1);
+        public DateTime ToDate { get; set; } = DateTime.Now;
+        public int? BranchId { get; set; }
+        public List<GeneralLedgerAccountViewModel> Accounts { get; set; } = new List<GeneralLedgerAccountViewModel>();
+        public List<SelectListItem> AccountOptions { get; set; } = new List<SelectListItem>();
+        public List<SelectListItem> Branches { get; set; } = new List<SelectListItem>();
+    }
+
+    public class GeneralLedgerAccountViewModel
+    {
+        public string AccountCode { get; set; } = string.Empty;
+        public string AccountName { get; set; } = string.Empty;
+        public List<GeneralLedgerTransactionViewModel> Transactions { get; set; } = new List<GeneralLedgerTransactionViewModel>();
+    }
+
+    public class GeneralLedgerTransactionViewModel
+    {
+        public DateTime Date { get; set; }
+        public string JournalEntryNumber { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public decimal DebitAmount { get; set; }
+        public decimal CreditAmount { get; set; }
+    }
+
     // User Management ViewModels
     public class CreateUserViewModel
     {

--- a/AccountingSystem/ViewModels/UserViewModels.cs
+++ b/AccountingSystem/ViewModels/UserViewModels.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace AccountingSystem.ViewModels
+{
+    public class UserListViewModel
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
+        public string FullName { get; set; } = string.Empty;
+        public bool IsActive { get; set; }
+    }
+
+    public class PermissionSelectionViewModel
+    {
+        public int PermissionId { get; set; }
+        public string DisplayName { get; set; } = string.Empty;
+        public string Category { get; set; } = string.Empty;
+        public bool IsGranted { get; set; }
+    }
+
+    public class ManageUserPermissionsViewModel
+    {
+        public string UserId { get; set; } = string.Empty;
+        public string UserName { get; set; } = string.Empty;
+        public List<PermissionSelectionViewModel> Permissions { get; set; } = new List<PermissionSelectionViewModel>();
+    }
+}

--- a/AccountingSystem/Views/CostCenters/Report.cshtml
+++ b/AccountingSystem/Views/CostCenters/Report.cshtml
@@ -1,0 +1,88 @@
+@model AccountingSystem.ViewModels.CostCenterReportViewModel
+@{
+    ViewData["Title"] = "تقرير مركز التكلفة";
+    Layout = "~/Views/Shared/_AccountingLayout.cshtml";
+}
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">
+            <div class="card shadow">
+                <div class="card-header bg-success text-white">
+                    <h4 class="mb-0"><i class="fas fa-balance-scale me-2"></i>تقرير مركز التكلفة</h4>
+                </div>
+                <div class="card-body">
+                    <form method="get" class="row g-3 mb-4">
+                        <input type="hidden" name="id" value="@Model.CostCenter.Id" />
+                        <div class="col-md-3">
+                            <label class="form-label">من تاريخ</label>
+                            <input type="date" name="fromDate" class="form-control" value="@Model.FromDate.ToString("yyyy-MM-dd")" />
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label">إلى تاريخ</label>
+                            <input type="date" name="toDate" class="form-control" value="@Model.ToDate.ToString("yyyy-MM-dd")" />
+                        </div>
+                        <div class="col-md-3 align-self-end">
+                            <button type="submit" class="btn btn-success w-100"><i class="fas fa-search me-1"></i>عرض</button>
+                        </div>
+                    </form>
+
+                    <h5>@Model.CostCenter.NameAr (@Model.CostCenter.Code)</h5>
+                    <div class="table-responsive">
+                        <table class="table table-striped table-hover">
+                            <thead class="table-dark">
+                                <tr>
+                                    <th>التاريخ</th>
+                                    <th>المرجع</th>
+                                    <th>الحساب</th>
+                                    <th>الوصف</th>
+                                    <th>مدين</th>
+                                    <th>دائن</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var t in Model.Transactions)
+                                {
+                                    <tr>
+                                        <td>@t.Date.ToString("yyyy-MM-dd")</td>
+                                        <td>@t.Reference</td>
+                                        <td>@t.AccountName</td>
+                                        <td>@t.Description</td>
+                                        <td class="text-end">@t.DebitAmount.ToString("N2")</td>
+                                        <td class="text-end">@t.CreditAmount.ToString("N2")</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div class="row mt-4">
+                        <div class="col-md-4">
+                            <div class="card border-success">
+                                <div class="card-body text-center">
+                                    <h6>إجمالي المدين</h6>
+                                    <h4 class="text-success">@Model.TotalDebit.ToString("N2")</h4>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-md-4">
+                            <div class="card border-danger">
+                                <div class="card-body text-center">
+                                    <h6>إجمالي الدائن</h6>
+                                    <h4 class="text-danger">@Model.TotalCredit.ToString("N2")</h4>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-md-4">
+                            <div class="card border-primary">
+                                <div class="card-body text-center">
+                                    <h6>الرصيد</h6>
+                                    <h4 class="text-primary">@((Model.TotalDebit - Model.TotalCredit).ToString("N2"))</h4>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/AccountingSystem/Views/JournalEntries/Draft.cshtml
+++ b/AccountingSystem/Views/JournalEntries/Draft.cshtml
@@ -1,0 +1,68 @@
+@model JournalEntriesIndexViewModel
+@using AccountingSystem.ViewModels
+@{
+    ViewData["Title"] = "القيود المسودة";
+    Layout = "~/Views/Shared/_AccountingLayout.cshtml";
+}
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <h3 class="card-title mb-0">
+                        <i class="fas fa-file-invoice me-2"></i>
+                        القيود المسودة
+                    </h3>
+                    <a asp-action="Create" class="btn btn-primary">
+                        <i class="fas fa-plus me-1"></i>
+                        إضافة قيد جديد
+                    </a>
+                </div>
+                <div class="card-body">
+                    <div class="table-responsive">
+                        <table class="table table-striped table-hover">
+                            <thead class="table-dark">
+                                <tr>
+                                    <th>رقم القيد</th>
+                                    <th>التاريخ</th>
+                                    <th>الوصف</th>
+                                    <th>المرجع</th>
+                                    <th>الفرع</th>
+                                    <th>المبلغ الإجمالي</th>
+                                    <th>عدد البنود</th>
+                                    <th>الحالة</th>
+                                    <th>الإجراءات</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var entry in Model.JournalEntries)
+                                {
+                                    <tr>
+                                        <td>@entry.Number</td>
+                                        <td>@entry.Date.ToString("yyyy-MM-dd")</td>
+                                        <td>@entry.Description</td>
+                                        <td>@entry.Reference</td>
+                                        <td>@entry.BranchName</td>
+                                        <td>@entry.TotalAmount.ToString("N2") ريال</td>
+                                        <td>@entry.LinesCount</td>
+                                        <td><span class="badge bg-secondary">مسودة</span></td>
+                                        <td>
+                                            <div class="btn-group" role="group">
+                                                <a asp-action="Details" asp-route-id="@entry.Id" class="btn btn-sm btn-outline-info">
+                                                    <i class="fas fa-eye"></i>
+                                                </a>
+                                                <a asp-action="Edit" asp-route-id="@entry.Id" class="btn btn-sm btn-outline-warning">
+                                                    <i class="fas fa-edit"></i>
+                                                </a>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/AccountingSystem/Views/JournalEntries/Posted.cshtml
+++ b/AccountingSystem/Views/JournalEntries/Posted.cshtml
@@ -1,0 +1,61 @@
+@model JournalEntriesIndexViewModel
+@using AccountingSystem.ViewModels
+@{
+    ViewData["Title"] = "القيود المرحلة";
+    Layout = "~/Views/Shared/_AccountingLayout.cshtml";
+}
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <h3 class="card-title mb-0">
+                        <i class="fas fa-file-invoice me-2"></i>
+                        القيود المرحلة
+                    </h3>
+                </div>
+                <div class="card-body">
+                    <div class="table-responsive">
+                        <table class="table table-striped table-hover">
+                            <thead class="table-dark">
+                                <tr>
+                                    <th>رقم القيد</th>
+                                    <th>التاريخ</th>
+                                    <th>الوصف</th>
+                                    <th>المرجع</th>
+                                    <th>الفرع</th>
+                                    <th>المبلغ الإجمالي</th>
+                                    <th>عدد البنود</th>
+                                    <th>الحالة</th>
+                                    <th>الإجراءات</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var entry in Model.JournalEntries)
+                                {
+                                    <tr>
+                                        <td>@entry.Number</td>
+                                        <td>@entry.Date.ToString("yyyy-MM-dd")</td>
+                                        <td>@entry.Description</td>
+                                        <td>@entry.Reference</td>
+                                        <td>@entry.BranchName</td>
+                                        <td>@entry.TotalAmount.ToString("N2") ريال</td>
+                                        <td>@entry.LinesCount</td>
+                                        <td><span class="badge bg-success">مرحل</span></td>
+                                        <td>
+                                            <div class="btn-group" role="group">
+                                                <a asp-action="Details" asp-route-id="@entry.Id" class="btn btn-sm btn-outline-info">
+                                                    <i class="fas fa-eye"></i>
+                                                </a>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/AccountingSystem/Views/Reports/GeneralLedger.cshtml
+++ b/AccountingSystem/Views/Reports/GeneralLedger.cshtml
@@ -1,0 +1,93 @@
+@model AccountingSystem.ViewModels.GeneralLedgerViewModel
+@{
+    ViewData["Title"] = "دفتر الأستاذ العام";
+    Layout = "~/Views/Shared/_AccountingLayout.cshtml";
+}
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">
+            <div class="card shadow">
+                <div class="card-header bg-info text-white">
+                    <h4 class="mb-0"><i class="fas fa-book me-2"></i>دفتر الأستاذ العام</h4>
+                </div>
+                <div class="card-body">
+                    <form method="get" class="row g-3 mb-4">
+                        <div class="col-md-3">
+                            <label class="form-label">الحساب</label>
+                            <select name="accountId" class="form-select">
+                                <option value="">جميع الحسابات</option>
+                                @foreach (var acc in Model.AccountOptions)
+                                {
+                                    <option value="@acc.Value" @(Model.AccountId?.ToString() == acc.Value ? "selected" : "")>@acc.Text</option>
+                                }
+                            </select>
+                        </div>
+                        <div class="col-md-2">
+                            <label class="form-label">الفرع</label>
+                            <select name="branchId" class="form-select">
+                                <option value="">جميع الفروع</option>
+                                @foreach (var branch in Model.Branches)
+                                {
+                                    <option value="@branch.Value" @(Model.BranchId?.ToString() == branch.Value ? "selected" : "")>@branch.Text</option>
+                                }
+                            </select>
+                        </div>
+                        <div class="col-md-2">
+                            <label class="form-label">من تاريخ</label>
+                            <input type="date" name="fromDate" class="form-control" value="@Model.FromDate.ToString("yyyy-MM-dd")" />
+                        </div>
+                        <div class="col-md-2">
+                            <label class="form-label">إلى تاريخ</label>
+                            <input type="date" name="toDate" class="form-control" value="@Model.ToDate.ToString("yyyy-MM-dd")" />
+                        </div>
+                        <div class="col-md-3 align-self-end">
+                            <button type="submit" class="btn btn-info w-100">
+                                <i class="fas fa-search me-1"></i>عرض
+                            </button>
+                        </div>
+                    </form>
+
+                    @if (Model.Accounts.Any())
+                    {
+                        foreach (var account in Model.Accounts)
+                        {
+                            <h5 class="mt-4">@account.AccountCode - @account.AccountName</h5>
+                            <div class="table-responsive">
+                                <table class="table table-striped table-hover">
+                                    <thead class="table-dark">
+                                        <tr>
+                                            <th>التاريخ</th>
+                                            <th>رقم القيد</th>
+                                            <th>البيان</th>
+                                            <th>مدين</th>
+                                            <th>دائن</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @foreach (var t in account.Transactions)
+                                        {
+                                            <tr>
+                                                <td>@t.Date.ToString("yyyy-MM-dd")</td>
+                                                <td>@t.JournalEntryNumber</td>
+                                                <td>@t.Description</td>
+                                                <td class="text-end">@t.DebitAmount.ToString("N2")</td>
+                                                <td class="text-end">@t.CreditAmount.ToString("N2")</td>
+                                            </tr>
+                                        }
+                                    </tbody>
+                                </table>
+                            </div>
+                        }
+                    }
+                    else
+                    {
+                        <div class="text-center text-muted py-5">
+                            <i class="fas fa-inbox fa-2x mb-2"></i>
+                            <br />لا توجد بيانات للفترة المحددة
+                        </div>
+                    }
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/AccountingSystem/Views/Users/Index.cshtml
+++ b/AccountingSystem/Views/Users/Index.cshtml
@@ -1,0 +1,32 @@
+@model IEnumerable<AccountingSystem.ViewModels.UserListViewModel>
+@{
+    ViewData["Title"] = "المستخدمون";
+}
+
+<h1 class="mb-4">المستخدمون</h1>
+
+<table class="table table-bordered table-striped">
+    <thead>
+        <tr>
+            <th>البريد الإلكتروني</th>
+            <th>الاسم</th>
+            <th>نشط</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach (var user in Model)
+    {
+        <tr>
+            <td>@user.Email</td>
+            <td>@user.FullName</td>
+            <td>@(user.IsActive ? "نعم" : "لا")</td>
+            <td>
+                <a class="btn btn-sm btn-primary" asp-action="ManagePermissions" asp-route-id="@user.Id">
+                    <i class="fas fa-key"></i> الصلاحيات
+                </a>
+            </td>
+        </tr>
+    }
+    </tbody>
+</table>

--- a/AccountingSystem/Views/Users/ManagePermissions.cshtml
+++ b/AccountingSystem/Views/Users/ManagePermissions.cshtml
@@ -1,0 +1,29 @@
+@model AccountingSystem.ViewModels.ManageUserPermissionsViewModel
+@{
+    ViewData["Title"] = "صلاحيات المستخدم";
+}
+
+<h1 class="mb-4">صلاحيات المستخدم - @Model.UserName</h1>
+
+<form asp-action="ManagePermissions" method="post">
+    <input type="hidden" asp-for="UserId" />
+    @for (int i = 0; i < Model.Permissions.Count; i++)
+    {
+        var perm = Model.Permissions[i];
+        if (i == 0 || Model.Permissions[i - 1].Category != perm.Category)
+        {
+            <h5 class="mt-3">@perm.Category</h5>
+        }
+        <div class="form-check ms-3">
+            <input asp-for="Permissions[i].IsGranted" class="form-check-input" />
+            <input asp-for="Permissions[i].PermissionId" type="hidden" />
+            <input asp-for="Permissions[i].DisplayName" type="hidden" />
+            <input asp-for="Permissions[i].Category" type="hidden" />
+            <label class="form-check-label" asp-for="Permissions[i].IsGranted">@perm.DisplayName</label>
+        </div>
+    }
+    <div class="mt-4">
+        <button type="submit" class="btn btn-primary"><i class="fas fa-save"></i> حفظ</button>
+        <a asp-action="Index" class="btn btn-secondary">عودة</a>
+    </div>
+</form>


### PR DESCRIPTION
## Summary
- enforce permission policies across controllers for fine-grained access control
- add report actions for account statements and general ledger with corresponding views
- implement cost center report and journal entry draft/posted listings, and seed admin with all permissions

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0. Either target .NET 8.0 or lower, or use a version of the .NET SDK that supports .NET 9.0.)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a555ea4483339a32d7f97707b051