### PR TITLE
Preselect parent on account creation and add edit support

### DIFF
--- a/AccountingSystem/ViewModels/SimpleViewModels.cs
+++ b/AccountingSystem/ViewModels/SimpleViewModels.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc.Rendering;
 using AccountingSystem.Models;
+using System.ComponentModel.DataAnnotations;
 
 namespace AccountingSystem.ViewModels
 {
@@ -10,6 +11,7 @@ namespace AccountingSystem.ViewModels
         public DateTime Date { get; set; } = DateTime.Now;
         public string Description { get; set; } = string.Empty;
         public string? Reference { get; set; }
+        [Range(1, int.MaxValue, ErrorMessage = "يجب اختيار الفرع")]
         public int BranchId { get; set; }
         public int? CostCenterId { get; set; }
         public List<JournalEntryLineViewModel> Lines { get; set; } = new List<JournalEntryLineViewModel>();
@@ -41,7 +43,7 @@ namespace AccountingSystem.ViewModels
         public bool IsActive { get; set; } = true;
         public bool CanPostTransactions { get; set; } = true;
         public int? ParentId { get; set; }
-        public int BranchId { get; set; }
+        public int? BranchId { get; set; }
         public int? CostCenterId { get; set; }
         public List<SelectListItem> ParentAccounts { get; set; } = new List<SelectListItem>();
         public List<SelectListItem> Branches { get; set; } = new List<SelectListItem>();
@@ -61,7 +63,7 @@ namespace AccountingSystem.ViewModels
         public bool IsActive { get; set; }
         public bool CanPostTransactions { get; set; }
         public int? ParentId { get; set; }
-        public int BranchId { get; set; }
+        public int? BranchId { get; set; }
         public int? CostCenterId { get; set; }
         public List<SelectListItem> ParentAccounts { get; set; } = new List<SelectListItem>();
         public List<SelectListItem> Branches { get; set; } = new List<SelectListItem>();
@@ -83,7 +85,7 @@ namespace AccountingSystem.ViewModels
         public bool CanPostTransactions { get; set; }
         public int? ParentId { get; set; }
         public string ParentAccountName { get; set; } = string.Empty;
-        public int BranchId { get; set; }
+        public int? BranchId { get; set; }
         public string BranchName { get; set; } = string.Empty;
         public int? CostCenterId { get; set; }
         public string CostCenterName { get; set; } = string.Empty;

--- a/AccountingSystem/ViewModels/SimpleViewModels.cs
+++ b/AccountingSystem/ViewModels/SimpleViewModels.cs
@@ -44,10 +44,8 @@ namespace AccountingSystem.ViewModels
         public bool CanPostTransactions { get; set; } = true;
         public int? ParentId { get; set; }
         public int? BranchId { get; set; }
-        public int? CostCenterId { get; set; }
         public List<SelectListItem> ParentAccounts { get; set; } = new List<SelectListItem>();
         public List<SelectListItem> Branches { get; set; } = new List<SelectListItem>();
-        public List<SelectListItem> CostCenters { get; set; } = new List<SelectListItem>();
     }
 
     public class EditAccountViewModel
@@ -64,10 +62,8 @@ namespace AccountingSystem.ViewModels
         public bool CanPostTransactions { get; set; }
         public int? ParentId { get; set; }
         public int? BranchId { get; set; }
-        public int? CostCenterId { get; set; }
         public List<SelectListItem> ParentAccounts { get; set; } = new List<SelectListItem>();
         public List<SelectListItem> Branches { get; set; } = new List<SelectListItem>();
-        public List<SelectListItem> CostCenters { get; set; } = new List<SelectListItem>();
     }
 
     public class AccountViewModel
@@ -87,11 +83,41 @@ namespace AccountingSystem.ViewModels
         public string ParentAccountName { get; set; } = string.Empty;
         public int? BranchId { get; set; }
         public string BranchName { get; set; } = string.Empty;
-        public int? CostCenterId { get; set; }
-        public string CostCenterName { get; set; } = string.Empty;
         public int Level { get; set; }
         public bool HasChildren { get; set; }
         public bool HasTransactions { get; set; }
+    }
+
+    public class AccountDetailsViewModel
+    {
+        public int Id { get; set; }
+        public string Code { get; set; } = string.Empty;
+        public string NameAr { get; set; } = string.Empty;
+        public string NameEn { get; set; } = string.Empty;
+        public AccountType AccountType { get; set; }
+        public AccountNature Nature { get; set; }
+        public AccountSubClassification SubClassification { get; set; }
+        public decimal OpeningBalance { get; set; }
+        public decimal CurrentBalance { get; set; }
+        public bool IsActive { get; set; }
+        public bool CanPostTransactions { get; set; }
+        public bool RequiresCostCenter { get; set; }
+        public int Level { get; set; }
+        public int? ParentAccountId { get; set; }
+        public string ParentAccountName { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public DateTime CreatedAt { get; set; }
+        public List<AccountDetailsChildViewModel> ChildAccounts { get; set; } = new List<AccountDetailsChildViewModel>();
+    }
+
+    public class AccountDetailsChildViewModel
+    {
+        public int Id { get; set; }
+        public string Code { get; set; } = string.Empty;
+        public string NameAr { get; set; } = string.Empty;
+        public AccountSubClassification SubClassification { get; set; }
+        public decimal CurrentBalance { get; set; }
+        public bool IsActive { get; set; }
     }
 
     // Report ViewModels

--- a/AccountingSystem/ViewModels/UserViewModels.cs
+++ b/AccountingSystem/ViewModels/UserViewModels.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace AccountingSystem.ViewModels
 {
@@ -45,6 +46,9 @@ namespace AccountingSystem.ViewModels
         public string Password { get; set; } = string.Empty;
 
         public bool IsActive { get; set; } = true;
+        [MinLength(1, ErrorMessage = "يجب اختيار فرع واحد على الأقل")]
+        public List<int> BranchIds { get; set; } = new List<int>();
+        public List<SelectListItem> Branches { get; set; } = new List<SelectListItem>();
     }
 
     public class EditUserViewModel
@@ -65,5 +69,8 @@ namespace AccountingSystem.ViewModels
         public string LastName { get; set; } = string.Empty;
 
         public bool IsActive { get; set; } = true;
+        [MinLength(1, ErrorMessage = "يجب اختيار فرع واحد على الأقل")]
+        public List<int> BranchIds { get; set; } = new List<int>();
+        public List<SelectListItem> Branches { get; set; } = new List<SelectListItem>();
     }
 }

--- a/AccountingSystem/Views/Accounts/Create.cshtml
+++ b/AccountingSystem/Views/Accounts/Create.cshtml
@@ -2,7 +2,8 @@
 
 @{
     ViewData["Title"] = "إضافة حساب جديد";
-    Layout = "_AccountingLayout";
+    var isModal = ViewData["IsModal"] as bool? ?? false;
+    Layout = isModal ? null : "_AccountingLayout";
 }
 
 <div class="container-fluid">

--- a/AccountingSystem/Views/Accounts/Edit.cshtml
+++ b/AccountingSystem/Views/Accounts/Edit.cshtml
@@ -2,7 +2,8 @@
 
 @{
     ViewData["Title"] = "تعديل الحساب";
-    Layout = "_AccountingLayout";
+    var isModal = ViewData["IsModal"] as bool? ?? false;
+    Layout = isModal ? null : "_AccountingLayout";
 }
 
 <div class="container-fluid">

--- a/AccountingSystem/Views/Accounts/Tree.cshtml
+++ b/AccountingSystem/Views/Accounts/Tree.cshtml
@@ -123,12 +123,17 @@
 }
 
 @section Scripts {
+    <div class="modal fade" id="accountModal" tabindex="-1">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content"></div>
+        </div>
+    </div>
     <script>
-        $(document).ready(function() {
-            $('.toggle-btn').click(function() {
+        $(document).ready(function () {
+            $('.toggle-btn').click(function () {
                 var $this = $(this);
                 var $children = $this.closest('.tree-node').find('> .tree-children');
-                
+
                 if ($children.is(':visible')) {
                     $children.hide();
                     $this.html('<i class="fas fa-plus"></i>');
@@ -137,14 +142,39 @@
                     $this.html('<i class="fas fa-minus"></i>');
                 }
             });
-            
-            // Expand first level by default
+
             $('.tree-node[data-level="0"] .toggle-btn').click();
+
+            $(document).on('click', '.ajax-modal', function (e) {
+                e.preventDefault();
+                var url = $(this).attr('href');
+                $('#accountModal .modal-content').load(url, function () {
+                    $('#accountModal').modal('show');
+                });
+            });
+
+            $(document).on('submit', '#accountModal form', function (e) {
+                e.preventDefault();
+                var form = $(this);
+                $.ajax({
+                    url: form.attr('action'),
+                    method: form.attr('method'),
+                    data: form.serialize(),
+                    success: function (result) {
+                        if (result.success) {
+                            $('#accountModal').modal('hide');
+                            location.reload();
+                        } else {
+                            $('#accountModal .modal-content').html(result);
+                        }
+                    }
+                });
+            });
         });
-        
+
         function deleteAccount(id) {
             if (confirm('هل أنت متأكد من حذف هذا الحساب؟')) {
-                $.post('@Url.Action("Delete")', { id: id }, function(result) {
+                $.post('@Url.Action("Delete")', { id: id }, function (result) {
                     if (result.success) {
                         location.reload();
                     } else {

--- a/AccountingSystem/Views/Accounts/_AccountTreeNode.cshtml
+++ b/AccountingSystem/Views/Accounts/_AccountTreeNode.cshtml
@@ -51,11 +51,11 @@
                             <i class="fas fa-eye"></i>
                         </a>
                         <a href="@Url.Action("Edit", new { id = node.Id })"
-                           class="btn btn-outline-warning" title="تعديل">
+                           class="btn btn-outline-warning ajax-modal" title="تعديل">
                             <i class="fas fa-edit"></i>
                         </a>
                         <a href="@Url.Action("Create", new { parentId = node.Id })"
-                           class="btn btn-outline-primary" title="إضافة حساب فرعي">
+                           class="btn btn-outline-primary ajax-modal" title="إضافة حساب فرعي">
                             <i class="fas fa-plus"></i>
                         </a>
                         @if (node.CanPostTransactions)

--- a/AccountingSystem/Views/Users/Create.cshtml
+++ b/AccountingSystem/Views/Users/Create.cshtml
@@ -27,6 +27,11 @@
             <input asp-for="Password" class="form-control" />
             <span asp-validation-for="Password" class="text-danger"></span>
         </div>
+        <div class="mb-3">
+            <label class="form-label">الفروع</label>
+            <select asp-for="BranchIds" asp-items="Model.Branches" class="form-select" multiple></select>
+            <span asp-validation-for="BranchIds" class="text-danger"></span>
+        </div>
         <div class="form-check mb-3">
             <input asp-for="IsActive" class="form-check-input" />
             <label asp-for="IsActive" class="form-check-label"></label>

--- a/AccountingSystem/Views/Users/Edit.cshtml
+++ b/AccountingSystem/Views/Users/Edit.cshtml
@@ -23,6 +23,11 @@
             <input asp-for="LastName" class="form-control" />
             <span asp-validation-for="LastName" class="text-danger"></span>
         </div>
+        <div class="mb-3">
+            <label class="form-label">الفروع</label>
+            <select asp-for="BranchIds" asp-items="Model.Branches" class="form-select" multiple></select>
+            <span asp-validation-for="BranchIds" class="text-danger"></span>
+        </div>
         <div class="form-check mb-3">
             <input asp-for="IsActive" class="form-check-input" />
             <label asp-for="IsActive" class="form-check-label"></label>


### PR DESCRIPTION
## Summary
- Default the selected account as the parent when adding from the tree
- Add missing edit actions for accounts
- Validate branch selection when creating journal entries

## Testing
- `dotnet build AccountingSystem/AccountingSystem.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b1bdaa6a04833390df8a13e682ac07