### PR TITLE
Include unassigned accounts in branch reports

### DIFF
--- a/AccountingSystem/Controllers/ReportsController.cs
+++ b/AccountingSystem/Controllers/ReportsController.cs
@@ -30,7 +30,7 @@ namespace AccountingSystem.Controllers
             var accounts = await _context.Accounts
                 .Include(a => a.Branch)
                 .Where(a => a.CanPostTransactions)
-                .Where(a => !branchId.HasValue || a.BranchId == branchId)
+                .Where(a => !branchId.HasValue || a.BranchId == branchId || a.BranchId == null)
                 .OrderBy(a => a.Code)
                 .ToListAsync();
 
@@ -61,7 +61,7 @@ namespace AccountingSystem.Controllers
             var accounts = await _context.Accounts
                 .Include(a => a.Branch)
                 .Where(a => a.CanPostTransactions)
-                .Where(a => !branchId.HasValue || a.BranchId == branchId)
+                .Where(a => !branchId.HasValue || a.BranchId == branchId || a.BranchId == null)
                 .OrderBy(a => a.Code)
                 .ToListAsync();
 
@@ -103,7 +103,7 @@ namespace AccountingSystem.Controllers
             var accounts = await _context.Accounts
                 .Include(a => a.Branch)
                 .Where(a => a.CanPostTransactions)
-                .Where(a => !branchId.HasValue || a.BranchId == branchId)
+                .Where(a => !branchId.HasValue || a.BranchId == branchId || a.BranchId == null)
                 .OrderBy(a => a.Code)
                 .ToListAsync();
 


### PR DESCRIPTION
## Summary
- Include accounts without a branch when generating trial balance, balance sheet and income statement reports so branch reports reflect all relevant entries

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b2086086b48333af30c6c08d2c4801