### PR TITLE
Add user profile and management operations

### DIFF
--- a/AccountingSystem/ViewModels/UserViewModels.cs
+++ b/AccountingSystem/ViewModels/UserViewModels.cs
@@ -9,6 +9,7 @@ namespace AccountingSystem.ViewModels
         public string Email { get; set; } = string.Empty;
         public string FullName { get; set; } = string.Empty;
         public bool IsActive { get; set; }
+        public DateTime? LastLoginAt { get; set; }
     }
 
     public class PermissionSelectionViewModel
@@ -82,5 +83,42 @@ namespace AccountingSystem.ViewModels
         public List<SelectListItem> Branches { get; set; } = new List<SelectListItem>();
         public List<SelectListItem> PaymentBranches { get; set; } = new List<SelectListItem>();
         public List<SelectListItem> PaymentAccounts { get; set; } = new List<SelectListItem>();
+    }
+
+    public class ResetUserPasswordViewModel
+    {
+        [Required]
+        public string Id { get; set; } = string.Empty;
+
+        [Required]
+        [StringLength(100, MinimumLength = 6)]
+        [DataType(DataType.Password)]
+        public string NewPassword { get; set; } = string.Empty;
+
+        [Required]
+        [DataType(DataType.Password)]
+        [Compare("NewPassword", ErrorMessage = "كلمتا المرور غير متطابقتين")] 
+        public string ConfirmPassword { get; set; } = string.Empty;
+    }
+
+    public class ProfileViewModel
+    {
+        public string Email { get; set; } = string.Empty;
+        public string FullName { get; set; } = string.Empty;
+        public DateTime? LastLoginAt { get; set; }
+
+        [Required]
+        [DataType(DataType.Password)]
+        public string CurrentPassword { get; set; } = string.Empty;
+
+        [Required]
+        [StringLength(100, MinimumLength = 6)]
+        [DataType(DataType.Password)]
+        public string NewPassword { get; set; } = string.Empty;
+
+        [Required]
+        [DataType(DataType.Password)]
+        [Compare("NewPassword", ErrorMessage = "كلمتا المرور غير متطابقتين")] 
+        public string ConfirmPassword { get; set; } = string.Empty;
     }
 }

--- a/AccountingSystem/Views/Account/Profile.cshtml
+++ b/AccountingSystem/Views/Account/Profile.cshtml
@@ -1,0 +1,42 @@
+@model AccountingSystem.ViewModels.ProfileViewModel
+@{
+    ViewData["Title"] = "الملف الشخصي";
+}
+
+<h1 class="mb-4">الملف الشخصي</h1>
+
+@if (TempData["SuccessMessage"] != null)
+{
+    <div class="alert alert-success">@TempData["SuccessMessage"]</div>
+}
+
+<div class="mb-3">
+    <p><strong>البريد الإلكتروني:</strong> @Model.Email</p>
+    <p><strong>الاسم:</strong> @Model.FullName</p>
+    <p><strong>آخر تسجيل دخول:</strong> @(Model.LastLoginAt?.ToString("yyyy-MM-dd HH:mm") ?? "-")</p>
+</div>
+
+<h3>تغيير كلمة المرور</h3>
+<form asp-action="Profile" method="post">
+    <div asp-validation-summary="All" class="text-danger"></div>
+    <div class="mb-3">
+        <label asp-for="CurrentPassword" class="form-label"></label>
+        <input asp-for="CurrentPassword" class="form-control" />
+        <span asp-validation-for="CurrentPassword" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="NewPassword" class="form-label"></label>
+        <input asp-for="NewPassword" class="form-control" />
+        <span asp-validation-for="NewPassword" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="ConfirmPassword" class="form-label"></label>
+        <input asp-for="ConfirmPassword" class="form-control" />
+        <span asp-validation-for="ConfirmPassword" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn btn-primary">تحديث كلمة المرور</button>
+</form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/AccountingSystem/Views/Users/Index.cshtml
+++ b/AccountingSystem/Views/Users/Index.cshtml
@@ -14,6 +14,7 @@
             <th>البريد الإلكتروني</th>
             <th>الاسم</th>
             <th>نشط</th>
+            <th>آخر تسجيل دخول</th>
             <th></th>
         </tr>
     </thead>
@@ -24,11 +25,20 @@
             <td>@user.Email</td>
             <td>@user.FullName</td>
             <td>@(user.IsActive ? "نعم" : "لا")</td>
+            <td>@(user.LastLoginAt?.ToString("yyyy-MM-dd HH:mm") ?? "-")</td>
             <td>
                 <a class="btn btn-sm btn-warning" asp-action="Edit" asp-route-id="@user.Id"><i class="fas fa-edit"></i></a>
                 <a class="btn btn-sm btn-primary" asp-action="ManagePermissions" asp-route-id="@user.Id">
                     <i class="fas fa-key"></i> الصلاحيات
                 </a>
+                <a class="btn btn-sm btn-secondary" asp-action="ResetPassword" asp-route-id="@user.Id">
+                    <i class="fas fa-lock"></i> كلمة مرور جديدة
+                </a>
+                <form asp-action="ToggleActive" asp-route-id="@user.Id" method="post" class="d-inline">
+                    <button type="submit" class="btn btn-sm @(user.IsActive ? "btn-danger" : "btn-success")">
+                        <i class="fas @(user.IsActive ? "fa-user-slash" : "fa-user")"></i> @(user.IsActive ? "إيقاف" : "تفعيل")
+                    </button>
+                </form>
             </td>
         </tr>
     }

--- a/AccountingSystem/Views/Users/ResetPassword.cshtml
+++ b/AccountingSystem/Views/Users/ResetPassword.cshtml
@@ -1,0 +1,27 @@
+@model AccountingSystem.ViewModels.ResetUserPasswordViewModel
+@{
+    ViewData["Title"] = "تعيين كلمة مرور جديدة";
+}
+
+<h1 class="mb-4">تعيين كلمة مرور جديدة</h1>
+
+<form asp-action="ResetPassword" method="post">
+    <input type="hidden" asp-for="Id" />
+    <div asp-validation-summary="All" class="text-danger"></div>
+    <div class="mb-3">
+        <label asp-for="NewPassword" class="form-label"></label>
+        <input asp-for="NewPassword" class="form-control" />
+        <span asp-validation-for="NewPassword" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="ConfirmPassword" class="form-label"></label>
+        <input asp-for="ConfirmPassword" class="form-control" />
+        <span asp-validation-for="ConfirmPassword" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn btn-primary">حفظ</button>
+    <a asp-action="Index" class="btn btn-secondary">رجوع</a>
+</form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}


### PR DESCRIPTION
## Summary
- Add user profile page with password update and last login display
- Allow admins to reset passwords, toggle user activation, and view last login
- Extend user view models and list to support last login and password management

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b23808db40833396bb65707d0f4562