### PR TITLE
Add basic user payment transfer module

### DIFF
--- a/AccountingSystem/Controllers/TransfersController.cs
+++ b/AccountingSystem/Controllers/TransfersController.cs
@@ -1,0 +1,149 @@
+using AccountingSystem.Data;
+using AccountingSystem.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Linq;
+
+namespace AccountingSystem.Controllers
+{
+    [Authorize(Policy = "transfers.view")]
+    public class TransfersController : Controller
+    {
+        private readonly ApplicationDbContext _context;
+        private readonly UserManager<User> _userManager;
+
+        public TransfersController(ApplicationDbContext context, UserManager<User> userManager)
+        {
+            _context = context;
+            _userManager = userManager;
+        }
+
+        public async Task<IActionResult> Index()
+        {
+            var userId = _userManager.GetUserId(User);
+            var transfers = await _context.PaymentTransfers
+                .Include(t => t.Sender)
+                .Include(t => t.Receiver)
+                .Where(t => t.SenderId == userId || t.ReceiverId == userId)
+                .OrderByDescending(t => t.CreatedAt)
+                .ToListAsync();
+            ViewBag.CurrentUserId = userId;
+            return View(transfers);
+        }
+
+        [Authorize(Policy = "transfers.create")]
+        public IActionResult Create()
+        {
+            ViewData["Users"] = new SelectList(_context.Users.ToList(), "Id", "FullName");
+            return View();
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        [Authorize(Policy = "transfers.create")]
+        public async Task<IActionResult> Create(string receiverId, decimal amount, string? notes)
+        {
+            var sender = await _userManager.GetUserAsync(User);
+            if (sender == null)
+                return Challenge();
+
+            var receiver = await _context.Users.FindAsync(receiverId);
+            if (receiver == null)
+            {
+                ModelState.AddModelError("receiverId", "المستلم غير موجود");
+                ViewData["Users"] = new SelectList(_context.Users.ToList(), "Id", "FullName");
+                return View();
+            }
+
+            var transfer = new PaymentTransfer
+            {
+                SenderId = sender.Id,
+                ReceiverId = receiver.Id,
+                FromPaymentAccountId = sender.PaymentAccountId ?? 0,
+                ToPaymentAccountId = receiver.PaymentAccountId ?? 0,
+                FromBranchId = sender.PaymentBranchId,
+                ToBranchId = receiver.PaymentBranchId,
+                Amount = amount,
+                Notes = notes,
+                Status = TransferStatus.Pending,
+                CreatedAt = DateTime.UtcNow
+            };
+
+            _context.PaymentTransfers.Add(transfer);
+            await _context.SaveChangesAsync();
+            return RedirectToAction(nameof(Index));
+        }
+
+        [Authorize(Policy = "transfers.approve")]
+        public async Task<IActionResult> Approve(int id, bool accept)
+        {
+            var userId = _userManager.GetUserId(User);
+            var transfer = await _context.PaymentTransfers.FindAsync(id);
+            if (transfer == null || transfer.ReceiverId != userId)
+                return NotFound();
+
+            transfer.Status = accept ? TransferStatus.Accepted : TransferStatus.Rejected;
+            await _context.SaveChangesAsync();
+            return RedirectToAction(nameof(Index));
+        }
+
+        [Authorize(Policy = "transfers.create")]
+        public async Task<IActionResult> Edit(int id)
+        {
+            var userId = _userManager.GetUserId(User);
+            var transfer = await _context.PaymentTransfers.FindAsync(id);
+            if (transfer == null || transfer.SenderId != userId || transfer.Status != TransferStatus.Pending)
+                return NotFound();
+
+            ViewData["Users"] = new SelectList(_context.Users.ToList(), "Id", "FullName", transfer.ReceiverId);
+            return View(transfer);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        [Authorize(Policy = "transfers.create")]
+        public async Task<IActionResult> Edit(int id, string receiverId, decimal amount, string? notes)
+        {
+            var userId = _userManager.GetUserId(User);
+            var transfer = await _context.PaymentTransfers.FindAsync(id);
+            if (transfer == null || transfer.SenderId != userId || transfer.Status != TransferStatus.Pending)
+                return NotFound();
+
+            var receiver = await _context.Users.FindAsync(receiverId);
+            if (receiver == null)
+            {
+                ModelState.AddModelError("receiverId", "المستلم غير موجود");
+                ViewData["Users"] = new SelectList(_context.Users.ToList(), "Id", "FullName", receiverId);
+                return View(transfer);
+            }
+
+            transfer.ReceiverId = receiver.Id;
+            transfer.ToPaymentAccountId = receiver.PaymentAccountId ?? 0;
+            transfer.ToBranchId = receiver.PaymentBranchId;
+            transfer.Amount = amount;
+            transfer.Notes = notes;
+
+            await _context.SaveChangesAsync();
+            return RedirectToAction(nameof(Index));
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        [Authorize(Policy = "transfers.create")]
+        public async Task<IActionResult> Delete(int id)
+        {
+            var userId = _userManager.GetUserId(User);
+            var transfer = await _context.PaymentTransfers.FindAsync(id);
+            if (transfer == null || transfer.SenderId != userId || transfer.Status != TransferStatus.Pending)
+                return NotFound();
+
+            _context.PaymentTransfers.Remove(transfer);
+            await _context.SaveChangesAsync();
+            return RedirectToAction(nameof(Index));
+        }
+    }
+}

--- a/AccountingSystem/Data/ApplicationDbContext.cs
+++ b/AccountingSystem/Data/ApplicationDbContext.cs
@@ -21,6 +21,7 @@ namespace AccountingSystem.Data
         public DbSet<UserBranch> UserBranches { get; set; }
         public DbSet<UserPermission> UserPermissions { get; set; }
         public DbSet<Expense> Expenses { get; set; }
+        public DbSet<PaymentTransfer> PaymentTransfers { get; set; }
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
@@ -148,6 +149,43 @@ namespace AccountingSystem.Data
                     .OnDelete(DeleteBehavior.Restrict);
             });
 
+            builder.Entity<PaymentTransfer>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.Amount).HasColumnType("decimal(18,2)");
+                entity.Property(e => e.Notes).HasMaxLength(500);
+
+                entity.HasOne(e => e.Sender)
+                    .WithMany()
+                    .HasForeignKey(e => e.SenderId)
+                    .OnDelete(DeleteBehavior.Restrict);
+
+                entity.HasOne(e => e.Receiver)
+                    .WithMany()
+                    .HasForeignKey(e => e.ReceiverId)
+                    .OnDelete(DeleteBehavior.Restrict);
+
+                entity.HasOne(e => e.FromPaymentAccount)
+                    .WithMany()
+                    .HasForeignKey(e => e.FromPaymentAccountId)
+                    .OnDelete(DeleteBehavior.Restrict);
+
+                entity.HasOne(e => e.ToPaymentAccount)
+                    .WithMany()
+                    .HasForeignKey(e => e.ToPaymentAccountId)
+                    .OnDelete(DeleteBehavior.Restrict);
+
+                entity.HasOne(e => e.FromBranch)
+                    .WithMany()
+                    .HasForeignKey(e => e.FromBranchId)
+                    .OnDelete(DeleteBehavior.Restrict);
+
+                entity.HasOne(e => e.ToBranch)
+                    .WithMany()
+                    .HasForeignKey(e => e.ToBranchId)
+                    .OnDelete(DeleteBehavior.Restrict);
+            });
+
             builder.Entity<User>(entity =>
             {
                 entity.HasOne(u => u.PaymentAccount)
@@ -249,7 +287,10 @@ namespace AccountingSystem.Data
                 new Permission { Id = 29, Name = "expenses.create", DisplayName = "إنشاء المصاريف", Category = "المصاريف", CreatedAt = createdAt },
                 new Permission { Id = 30, Name = "expenses.edit", DisplayName = "تعديل المصاريف", Category = "المصاريف", CreatedAt = createdAt },
                 new Permission { Id = 31, Name = "expenses.delete", DisplayName = "حذف المصاريف", Category = "المصاريف", CreatedAt = createdAt },
-                new Permission { Id = 32, Name = "expenses.approve", DisplayName = "اعتماد المصاريف", Category = "المصاريف", CreatedAt = createdAt }
+                new Permission { Id = 32, Name = "expenses.approve", DisplayName = "اعتماد المصاريف", Category = "المصاريف", CreatedAt = createdAt },
+                new Permission { Id = 33, Name = "transfers.view", DisplayName = "عرض الحوالات", Category = "الحوالات", CreatedAt = createdAt },
+                new Permission { Id = 34, Name = "transfers.create", DisplayName = "إنشاء الحوالات", Category = "الحوالات", CreatedAt = createdAt },
+                new Permission { Id = 35, Name = "transfers.approve", DisplayName = "اعتماد الحوالات", Category = "الحوالات", CreatedAt = createdAt }
             );
         }
     }

--- a/AccountingSystem/Data/SeedData.cs
+++ b/AccountingSystem/Data/SeedData.cs
@@ -90,7 +90,10 @@ namespace AccountingSystem.Data
                 new Permission { Name = "dashboard.view", DisplayName = "عرض لوحة التحكم", Category = "لوحة التحكم" },
                 new Permission { Name = "dashboard.widget.stats", DisplayName = "عرض لوحة التحكم stats", Category = "لوحة التحكم" },
                 new Permission { Name = "dashboard.widget.accounts", DisplayName = " accountsعرض لوحة التحكم", Category = "لوحة التحكم" },
-                new Permission { Name = "dashboard.widget.links", DisplayName = " linksعرض لوحة التحكم", Category = "لوحة التحكم" }
+                new Permission { Name = "dashboard.widget.links", DisplayName = " linksعرض لوحة التحكم", Category = "لوحة التحكم" },
+                new Permission { Name = "transfers.view", DisplayName = "عرض الحوالات", Category = "الحوالات" },
+                new Permission { Name = "transfers.create", DisplayName = "إنشاء الحوالات", Category = "الحوالات" },
+                new Permission { Name = "transfers.approve", DisplayName = "اعتماد الحوالات", Category = "الحوالات" }
             };
 
 

--- a/AccountingSystem/Models/PaymentTransfer.cs
+++ b/AccountingSystem/Models/PaymentTransfer.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace AccountingSystem.Models
+{
+    public class PaymentTransfer
+    {
+        public int Id { get; set; }
+
+        [Required]
+        public string SenderId { get; set; } = string.Empty;
+
+        [Required]
+        public string ReceiverId { get; set; } = string.Empty;
+
+        [Required]
+        public int FromPaymentAccountId { get; set; }
+
+        [Required]
+        public int ToPaymentAccountId { get; set; }
+
+        public int? FromBranchId { get; set; }
+        public int? ToBranchId { get; set; }
+
+        [Column(TypeName = "decimal(18,2)")]
+        public decimal Amount { get; set; }
+
+        [StringLength(500)]
+        public string? Notes { get; set; }
+
+        public TransferStatus Status { get; set; } = TransferStatus.Pending;
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+        // Navigation properties
+        public virtual User Sender { get; set; } = null!;
+        public virtual User Receiver { get; set; } = null!;
+        public virtual Account FromPaymentAccount { get; set; } = null!;
+        public virtual Account ToPaymentAccount { get; set; } = null!;
+        public virtual Branch? FromBranch { get; set; }
+        public virtual Branch? ToBranch { get; set; }
+    }
+
+    public enum TransferStatus
+    {
+        Pending = 1,
+        Accepted = 2,
+        Rejected = 3
+    }
+}

--- a/AccountingSystem/Views/Transfers/Create.cshtml
+++ b/AccountingSystem/Views/Transfers/Create.cshtml
@@ -1,0 +1,21 @@
+@{
+    ViewData["Title"] = "إنشاء حوالة";
+}
+
+<h2>إنشاء حوالة</h2>
+
+<form asp-action="Create" method="post">
+    <div class="form-group">
+        <label>المستلم</label>
+        <select name="receiverId" class="form-control" asp-items="ViewBag.Users"></select>
+    </div>
+    <div class="form-group">
+        <label>المبلغ</label>
+        <input type="number" step="0.01" name="amount" class="form-control" />
+    </div>
+    <div class="form-group">
+        <label>ملاحظات</label>
+        <textarea name="notes" class="form-control"></textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">إرسال</button>
+</form>

--- a/AccountingSystem/Views/Transfers/Edit.cshtml
+++ b/AccountingSystem/Views/Transfers/Edit.cshtml
@@ -1,0 +1,23 @@
+@model AccountingSystem.Models.PaymentTransfer
+@{
+    ViewData["Title"] = "تعديل حوالة";
+}
+
+<h2>تعديل حوالة</h2>
+
+<form asp-action="Edit" method="post">
+    <input type="hidden" name="id" value="@Model.Id" />
+    <div class="form-group">
+        <label>المستلم</label>
+        <select name="receiverId" class="form-control" asp-items="ViewBag.Users"></select>
+    </div>
+    <div class="form-group">
+        <label>المبلغ</label>
+        <input type="number" step="0.01" name="amount" class="form-control" value="@Model.Amount" />
+    </div>
+    <div class="form-group">
+        <label>ملاحظات</label>
+        <textarea name="notes" class="form-control">@Model.Notes</textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">حفظ</button>
+</form>

--- a/AccountingSystem/Views/Transfers/Index.cshtml
+++ b/AccountingSystem/Views/Transfers/Index.cshtml
@@ -1,0 +1,46 @@
+@model IEnumerable<AccountingSystem.Models.PaymentTransfer>
+
+<h2>الحوالات</h2>
+<table class="table">
+    <thead>
+        <tr>
+            <th>المرسل</th>
+            <th>المستلم</th>
+            <th>المبلغ</th>
+            <th>الحالة</th>
+            <th>التاريخ</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+@foreach (var item in Model)
+{
+        <tr>
+            <td>@(item.Sender?.FullName ?? item.SenderId)</td>
+            <td>@(item.Receiver?.FullName ?? item.ReceiverId)</td>
+            <td>@item.Amount</td>
+            <td>@item.Status</td>
+            <td>@item.CreatedAt.ToString("yyyy-MM-dd")</td>
+            <td>
+            @if (item.Status == AccountingSystem.Models.TransferStatus.Pending)
+            {
+                if (item.ReceiverId == ViewBag.CurrentUserId)
+                {
+                    <a asp-action="Approve" asp-route-id="@item.Id" asp-route-accept="true">استلام</a> |
+                    <a asp-action="Approve" asp-route-id="@item.Id" asp-route-accept="false">رفض</a>
+                }
+                else if (item.SenderId == ViewBag.CurrentUserId)
+                {
+                    <a asp-action="Edit" asp-route-id="@item.Id">تعديل</a> |
+                    <form asp-action="Delete" asp-route-id="@item.Id" method="post" style="display:inline">
+                        <button type="submit" class="btn btn-link p-0 m-0 align-baseline">حذف</button>
+                    </form>
+                }
+            }
+            </td>
+        </tr>
+}
+    </tbody>
+</table>
+
+<a asp-action="Create" class="btn btn-primary">إنشاء حوالة</a>


### PR DESCRIPTION
## Summary
- add `PaymentTransfer` entity for user-to-user account transfers
- seed permissions and add basic transfer controller and views
- allow senders to edit or delete their pending transfers

## Testing
- `dotnet --version`
- `dotnet build AccountingSystem/AccountingSystem.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b23cd9801c83339a3c64324aa29f9d