### PR TITLE
Fix pipe rendering in transfer index view

### DIFF
--- a/AccountingSystem/Views/Transfers/Index.cshtml
+++ b/AccountingSystem/Views/Transfers/Index.cshtml
@@ -26,12 +26,14 @@
             {
                 if (item.ReceiverId == ViewBag.CurrentUserId)
                 {
-                    <a asp-action="Approve" asp-route-id="@item.Id" asp-route-accept="true">استلام</a> |
+                    <a asp-action="Approve" asp-route-id="@item.Id" asp-route-accept="true">استلام</a>
+                    <span class="mx-1">|</span>
                     <a asp-action="Approve" asp-route-id="@item.Id" asp-route-accept="false">رفض</a>
                 }
                 else if (item.SenderId == ViewBag.CurrentUserId)
                 {
-                    <a asp-action="Edit" asp-route-id="@item.Id">تعديل</a> |
+                    <a asp-action="Edit" asp-route-id="@item.Id">تعديل</a>
+                    <span class="mx-1">|</span>
                     <form asp-action="Delete" asp-route-id="@item.Id" method="post" style="display:inline">
                         <button type="submit" class="btn btn-link p-0 m-0 align-baseline">حذف</button>
                     </form>


### PR DESCRIPTION
## Summary
- fix Razor markup in Transfers/Index view so pipes render as text

## Testing
- `dotnet build` *(fails: NETSDK1045: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b23f9cdf848333891add65b4534d0a