### PR TITLE
Add audit logging for database changes

### DIFF
--- a/AccountingSystem/Migrations/20250830005118_AddAuditLogs.Designer.cs
+++ b/AccountingSystem/Migrations/20250830005118_AddAuditLogs.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using AccountingSystem.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AccountingSystem.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250830005118_AddAuditLogs")]
+    partial class AddAuditLogs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.8");

--- a/AccountingSystem/Migrations/20250830005118_AddAuditLogs.cs
+++ b/AccountingSystem/Migrations/20250830005118_AddAuditLogs.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AccountingSystem.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAuditLogs : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AuditLogs",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    UserId = table.Column<string>(type: "TEXT", nullable: true),
+                    Timestamp = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    TableName = table.Column<string>(type: "TEXT", nullable: false),
+                    RecordId = table.Column<string>(type: "TEXT", nullable: true),
+                    Operation = table.Column<string>(type: "TEXT", nullable: false),
+                    ColumnName = table.Column<string>(type: "TEXT", nullable: true),
+                    OldValues = table.Column<string>(type: "TEXT", nullable: true),
+                    NewValues = table.Column<string>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AuditLogs", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AuditLogs");
+        }
+    }
+}

--- a/AccountingSystem/Models/AuditLog.cs
+++ b/AccountingSystem/Models/AuditLog.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace AccountingSystem.Models
+{
+    public class AuditLog
+    {
+        public int Id { get; set; }
+        public string? UserId { get; set; }
+        public DateTime Timestamp { get; set; }
+        public string TableName { get; set; }
+        public string? RecordId { get; set; }
+        public string Operation { get; set; }
+        public string? ColumnName { get; set; }
+        public string? OldValues { get; set; }
+        public string? NewValues { get; set; }
+    }
+}

--- a/AccountingSystem/Program.cs
+++ b/AccountingSystem/Program.cs
@@ -39,6 +39,7 @@ builder.Services.ConfigureApplicationCookie(options =>
 });
 
 builder.Services.AddControllersWithViews();
+builder.Services.AddHttpContextAccessor();
 builder.Services.AddSingleton<IAuthorizationPolicyProvider, PermissionPolicyProvider>();
 builder.Services.AddScoped<IAuthorizationHandler, PermissionHandler>();
 


### PR DESCRIPTION
## Summary
- record column names alongside old and new values for entity changes
- update AuditLogs table to store column name

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b249ffc07c8333bd1ea7ff2c356226