### PR TITLE
Add cash box closing module and dashboard balances

### DIFF
--- a/AccountingSystem/Controllers/CashBoxClosuresController.cs
+++ b/AccountingSystem/Controllers/CashBoxClosuresController.cs
@@ -1,0 +1,138 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Identity;
+using AccountingSystem.Data;
+using AccountingSystem.Models;
+using AccountingSystem.ViewModels;
+
+namespace AccountingSystem.Controllers
+{
+    [Authorize]
+    public class CashBoxClosuresController : Controller
+    {
+        private readonly ApplicationDbContext _context;
+        private readonly UserManager<User> _userManager;
+
+        public CashBoxClosuresController(ApplicationDbContext context, UserManager<User> userManager)
+        {
+            _context = context;
+            _userManager = userManager;
+        }
+
+        [Authorize(Policy = "cashclosures.create")]
+        public async Task<IActionResult> Create()
+        {
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null || user.PaymentAccountId == null || user.PaymentBranchId == null)
+                return NotFound();
+
+            var account = await _context.Accounts.FindAsync(user.PaymentAccountId);
+            var branch = await _context.Branches.FindAsync(user.PaymentBranchId);
+
+            var model = new CashBoxClosureCreateViewModel
+            {
+                AccountName = account?.NameAr ?? string.Empty,
+                BranchName = branch?.NameAr ?? string.Empty
+            };
+
+            return View(model);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        [Authorize(Policy = "cashclosures.create")]
+        public async Task<IActionResult> Create(CashBoxClosureCreateViewModel model)
+        {
+            if (!ModelState.IsValid)
+            {
+                return View(model);
+            }
+
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null || user.PaymentAccountId == null || user.PaymentBranchId == null)
+                return NotFound();
+
+            var account = await _context.Accounts.FindAsync(user.PaymentAccountId);
+            if (account == null)
+                return NotFound();
+
+            var closure = new CashBoxClosure
+            {
+                UserId = user.Id,
+                AccountId = account.Id,
+                BranchId = user.PaymentBranchId.Value,
+                CountedAmount = model.CountedAmount,
+                OpeningBalance = account.CurrentBalance,
+                ClosingBalance = model.CountedAmount,
+                Notes = model.Notes,
+                Status = CashBoxClosureStatus.Pending,
+                CreatedAt = DateTime.Now
+            };
+
+            _context.CashBoxClosures.Add(closure);
+            await _context.SaveChangesAsync();
+
+            return RedirectToAction(nameof(MyClosures));
+        }
+
+        [Authorize(Policy = "cashclosures.view")]
+        public async Task<IActionResult> MyClosures()
+        {
+            var userId = _userManager.GetUserId(User);
+            var closures = await _context.CashBoxClosures
+                .Include(c => c.Account)
+                .Include(c => c.Branch)
+                .Where(c => c.UserId == userId)
+                .OrderByDescending(c => c.CreatedAt)
+                .ToListAsync();
+            return View(closures);
+        }
+
+        [Authorize(Policy = "cashclosures.approve")]
+        public async Task<IActionResult> Pending()
+        {
+            var closures = await _context.CashBoxClosures
+                .Include(c => c.User)
+                .Include(c => c.Account)
+                .Include(c => c.Branch)
+                .Where(c => c.Status == CashBoxClosureStatus.Pending)
+                .OrderBy(c => c.CreatedAt)
+                .ToListAsync();
+            return View(closures);
+        }
+
+        [HttpPost]
+        [Authorize(Policy = "cashclosures.approve")]
+        public async Task<IActionResult> Approve(int id, bool matched, string? reason)
+        {
+            var closure = await _context.CashBoxClosures.FindAsync(id);
+            if (closure == null)
+                return NotFound();
+
+            var account = await _context.Accounts.FindAsync(closure.AccountId);
+            closure.Status = matched ? CashBoxClosureStatus.ApprovedMatched : CashBoxClosureStatus.ApprovedWithDifference;
+            closure.Reason = reason;
+            closure.ApprovedAt = DateTime.Now;
+            closure.ClosingDate = DateTime.Now;
+            closure.ClosingBalance = account?.CurrentBalance ?? closure.ClosingBalance;
+
+            await _context.SaveChangesAsync();
+            return RedirectToAction(nameof(Pending));
+        }
+
+        [HttpPost]
+        [Authorize(Policy = "cashclosures.approve")]
+        public async Task<IActionResult> Reject(int id, string reason)
+        {
+            var closure = await _context.CashBoxClosures.FindAsync(id);
+            if (closure == null)
+                return NotFound();
+
+            closure.Status = CashBoxClosureStatus.Rejected;
+            closure.Reason = reason;
+            await _context.SaveChangesAsync();
+            return RedirectToAction(nameof(Pending));
+        }
+    }
+}

--- a/AccountingSystem/Controllers/DashboardController.cs
+++ b/AccountingSystem/Controllers/DashboardController.cs
@@ -53,6 +53,16 @@ namespace AccountingSystem.Controllers
                     .Where(l => l.JournalEntry.Date >= startDate && l.JournalEntry.Date <= endDate && allowedBranchIds.Contains(l.JournalEntry.BranchId))
                     .Sum(l => l.DebitAmount - l.CreditAmount));
 
+            var cashBoxes = accounts
+                .Where(a => a.Code.StartsWith("1101"))
+                .Select(a => new CashBoxBalanceViewModel
+                {
+                    AccountName = a.NameAr,
+                    BranchName = a.Branch?.NameAr ?? string.Empty,
+                    Balance = accountBalances[a.Id]
+                })
+                .ToList();
+
             var nodes = accounts.Select(a => new AccountTreeNodeViewModel
             {
                 Id = a.Id,
@@ -119,7 +129,8 @@ namespace AccountingSystem.Controllers
                 TotalEquity = totals.ContainsKey(AccountType.Equity) ? totals[AccountType.Equity] : 0,
                 TotalRevenues = totals.ContainsKey(AccountType.Revenue) ? totals[AccountType.Revenue] : 0,
                 TotalExpenses = totals.ContainsKey(AccountType.Expenses) ? totals[AccountType.Expenses] : 0,
-                AccountTypeTrees = accountTypeTrees
+                AccountTypeTrees = accountTypeTrees,
+                CashBoxes = cashBoxes
             };
 
             viewModel.NetIncome = viewModel.TotalRevenues - viewModel.TotalExpenses;

--- a/AccountingSystem/Data/ApplicationDbContext.cs
+++ b/AccountingSystem/Data/ApplicationDbContext.cs
@@ -32,6 +32,7 @@ namespace AccountingSystem.Data
         public DbSet<Expense> Expenses { get; set; }
         public DbSet<PaymentTransfer> PaymentTransfers { get; set; }
         public DbSet<AuditLog> AuditLogs { get; set; }
+        public DbSet<CashBoxClosure> CashBoxClosures { get; set; }
 
         public override int SaveChanges()
         {
@@ -198,6 +199,30 @@ namespace AccountingSystem.Data
                 entity.HasOne(e => e.CostCenter)
                     .WithMany(e => e.JournalEntryLines)
                     .HasForeignKey(e => e.CostCenterId)
+                    .OnDelete(DeleteBehavior.Restrict);
+            });
+
+            // CashBoxClosure configuration
+            builder.Entity<CashBoxClosure>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.CountedAmount).HasColumnType("decimal(18,2)");
+                entity.Property(e => e.OpeningBalance).HasColumnType("decimal(18,2)");
+                entity.Property(e => e.ClosingBalance).HasColumnType("decimal(18,2)");
+
+                entity.HasOne(e => e.User)
+                    .WithMany(u => u.CashBoxClosures)
+                    .HasForeignKey(e => e.UserId)
+                    .OnDelete(DeleteBehavior.Restrict);
+
+                entity.HasOne(e => e.Account)
+                    .WithMany()
+                    .HasForeignKey(e => e.AccountId)
+                    .OnDelete(DeleteBehavior.Restrict);
+
+                entity.HasOne(e => e.Branch)
+                    .WithMany()
+                    .HasForeignKey(e => e.BranchId)
                     .OnDelete(DeleteBehavior.Restrict);
             });
 

--- a/AccountingSystem/Data/SeedData.cs
+++ b/AccountingSystem/Data/SeedData.cs
@@ -91,9 +91,13 @@ namespace AccountingSystem.Data
                 new Permission { Name = "dashboard.widget.stats", DisplayName = "عرض لوحة التحكم stats", Category = "لوحة التحكم" },
                 new Permission { Name = "dashboard.widget.accounts", DisplayName = " accountsعرض لوحة التحكم", Category = "لوحة التحكم" },
                 new Permission { Name = "dashboard.widget.links", DisplayName = " linksعرض لوحة التحكم", Category = "لوحة التحكم" },
+                new Permission { Name = "dashboard.widget.cashboxes", DisplayName = "عرض أرصدة الصناديق بلوحة التحكم", Category = "لوحة التحكم" },
                 new Permission { Name = "transfers.view", DisplayName = "عرض الحوالات", Category = "الحوالات" },
                 new Permission { Name = "transfers.create", DisplayName = "إنشاء الحوالات", Category = "الحوالات" },
-                new Permission { Name = "transfers.approve", DisplayName = "اعتماد الحوالات", Category = "الحوالات" }
+                new Permission { Name = "transfers.approve", DisplayName = "اعتماد الحوالات", Category = "الحوالات" },
+                new Permission { Name = "cashclosures.view", DisplayName = "عرض إغلاقات الصندوق", Category = "الصندوق" },
+                new Permission { Name = "cashclosures.create", DisplayName = "إنشاء إغلاق صندوق", Category = "الصندوق" },
+                new Permission { Name = "cashclosures.approve", DisplayName = "اعتماد إغلاق الصندوق", Category = "الصندوق" }
             };
 
 

--- a/AccountingSystem/Models/CashBoxClosure.cs
+++ b/AccountingSystem/Models/CashBoxClosure.cs
@@ -1,0 +1,58 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace AccountingSystem.Models
+{
+    public class CashBoxClosure
+    {
+        public int Id { get; set; }
+
+        [Required]
+        public string UserId { get; set; } = string.Empty;
+
+        [Required]
+        public int AccountId { get; set; }
+
+        [Required]
+        public int BranchId { get; set; }
+
+        [Required]
+        [Display(Name = "المبلغ المعدود")]
+        public decimal CountedAmount { get; set; }
+
+        [Display(Name = "الرصيد الافتتاحي")]
+        public decimal OpeningBalance { get; set; }
+
+        [Display(Name = "الرصيد الختامي")]
+        public decimal ClosingBalance { get; set; }
+
+        [Display(Name = "الملاحظات")]
+        [StringLength(500)]
+        public string? Notes { get; set; }
+
+        [Display(Name = "الحالة")]
+        public CashBoxClosureStatus Status { get; set; } = CashBoxClosureStatus.Pending;
+
+        [Display(Name = "السبب")]
+        [StringLength(500)]
+        public string? Reason { get; set; }
+
+        public DateTime CreatedAt { get; set; } = DateTime.Now;
+
+        public DateTime? ApprovedAt { get; set; }
+
+        public DateTime? ClosingDate { get; set; }
+
+        // Navigation properties
+        public virtual User? User { get; set; }
+        public virtual Account? Account { get; set; }
+        public virtual Branch? Branch { get; set; }
+    }
+
+    public enum CashBoxClosureStatus
+    {
+        Pending = 0,
+        ApprovedMatched = 1,
+        ApprovedWithDifference = 2,
+        Rejected = 3
+    }
+}

--- a/AccountingSystem/Models/User.cs
+++ b/AccountingSystem/Models/User.cs
@@ -33,6 +33,7 @@ namespace AccountingSystem.Models
         public virtual Account? PaymentAccount { get; set; }
         public virtual Branch? PaymentBranch { get; set; }
         public virtual ICollection<Expense> Expenses { get; set; } = new List<Expense>();
+        public virtual ICollection<CashBoxClosure> CashBoxClosures { get; set; } = new List<CashBoxClosure>();
     }
 }
 

--- a/AccountingSystem/ViewModels/CashBoxClosureViewModels.cs
+++ b/AccountingSystem/ViewModels/CashBoxClosureViewModels.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace AccountingSystem.ViewModels
+{
+    public class CashBoxClosureCreateViewModel
+    {
+        [Required]
+        [Display(Name = "المبلغ المعدود")]
+        public decimal CountedAmount { get; set; }
+
+        [Display(Name = "ملاحظات")]
+        [StringLength(500)]
+        public string? Notes { get; set; }
+
+        public string AccountName { get; set; } = string.Empty;
+        public string BranchName { get; set; } = string.Empty;
+    }
+}

--- a/AccountingSystem/ViewModels/SimpleViewModels.cs
+++ b/AccountingSystem/ViewModels/SimpleViewModels.cs
@@ -269,6 +269,13 @@ namespace AccountingSystem.ViewModels
 
 
     // Dashboard ViewModels
+    public class CashBoxBalanceViewModel
+    {
+        public string BranchName { get; set; } = string.Empty;
+        public string AccountName { get; set; } = string.Empty;
+        public decimal Balance { get; set; }
+    }
+
     public class DashboardViewModel
     {
         public int TotalAccounts { get; set; }
@@ -286,6 +293,7 @@ namespace AccountingSystem.ViewModels
         public DateTime ToDate { get; set; } = DateTime.Today;
         public List<SelectListItem> Branches { get; set; } = new List<SelectListItem>();
         public List<AccountTreeNodeViewModel> AccountTypeTrees { get; set; } = new List<AccountTreeNodeViewModel>();
+        public List<CashBoxBalanceViewModel> CashBoxes { get; set; } = new List<CashBoxBalanceViewModel>();
     }
 
     // Additional ViewModels

--- a/AccountingSystem/Views/CashBoxClosures/Create.cshtml
+++ b/AccountingSystem/Views/CashBoxClosures/Create.cshtml
@@ -1,0 +1,39 @@
+@model AccountingSystem.ViewModels.CashBoxClosureCreateViewModel
+@{
+    ViewData["Title"] = "إغلاق الصندوق";
+    Layout = "_AccountingLayout";
+}
+
+<div class="container mt-4">
+    <div class="card">
+        <div class="card-header">
+            <h5 class="card-title mb-0">إغلاق الصندوق</h5>
+        </div>
+        <div class="card-body">
+            <div class="mb-3">
+                <label class="form-label">الحساب</label>
+                <input type="text" class="form-control" value="@Model.AccountName" readonly />
+            </div>
+            <div class="mb-3">
+                <label class="form-label">الفرع</label>
+                <input type="text" class="form-control" value="@Model.BranchName" readonly />
+            </div>
+            <form asp-action="Create" method="post">
+                <div class="mb-3">
+                    <label asp-for="CountedAmount" class="form-label"></label>
+                    <input asp-for="CountedAmount" class="form-control" />
+                    <span asp-validation-for="CountedAmount" class="text-danger"></span>
+                </div>
+                <div class="mb-3">
+                    <label asp-for="Notes" class="form-label"></label>
+                    <textarea asp-for="Notes" class="form-control"></textarea>
+                </div>
+                <button type="submit" class="btn btn-primary">حفظ</button>
+            </form>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+}

--- a/AccountingSystem/Views/CashBoxClosures/MyClosures.cshtml
+++ b/AccountingSystem/Views/CashBoxClosures/MyClosures.cshtml
@@ -1,0 +1,46 @@
+@model IEnumerable<AccountingSystem.Models.CashBoxClosure>
+@{
+    ViewData["Title"] = "إغلاقات الصندوق";
+    Layout = "_AccountingLayout";
+}
+
+<div class="container mt-4">
+    <div class="card">
+        <div class="card-header">
+            <h5 class="card-title mb-0">إغلاقات الصندوق الخاصة بي</h5>
+        </div>
+        <div class="card-body">
+            @if (Model.Any())
+            {
+                <table class="table table-bordered">
+                    <thead>
+                        <tr>
+                            <th>التاريخ</th>
+                            <th>المبلغ المعدود</th>
+                            <th>الرصيد الافتتاحي</th>
+                            <th>الفرق</th>
+                            <th>الحالة</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var item in Model)
+                        {
+                            var diff = item.CountedAmount - item.OpeningBalance;
+                            <tr>
+                                <td>@item.CreatedAt.ToString("yyyy-MM-dd")</td>
+                                <td>@item.CountedAmount.ToString("N2")</td>
+                                <td>@item.OpeningBalance.ToString("N2")</td>
+                                <td class="@(diff == 0 ? "text-success" : "text-danger")">@diff.ToString("N2")</td>
+                                <td>@item.Status</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            }
+            else
+            {
+                <div class="alert alert-info text-center">لا توجد بيانات</div>
+            }
+        </div>
+    </div>
+</div>

--- a/AccountingSystem/Views/CashBoxClosures/Pending.cshtml
+++ b/AccountingSystem/Views/CashBoxClosures/Pending.cshtml
@@ -1,0 +1,67 @@
+@model IEnumerable<AccountingSystem.Models.CashBoxClosure>
+@{
+    ViewData["Title"] = "طلبات إغلاق الصندوق";
+    Layout = "_AccountingLayout";
+}
+
+<div class="container mt-4">
+    <div class="card">
+        <div class="card-header">
+            <h5 class="card-title mb-0">طلبات إغلاق الصندوق</h5>
+        </div>
+        <div class="card-body">
+            @if (Model.Any())
+            {
+                <table class="table table-bordered">
+                    <thead>
+                        <tr>
+                            <th>المستخدم</th>
+                            <th>الحساب</th>
+                            <th>الفرع</th>
+                            <th>المبلغ المعدود</th>
+                            <th>الرصيد</th>
+                            <th>الفرق</th>
+                            <th>الإجراءات</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var item in Model)
+                        {
+                            var diff = item.CountedAmount - item.OpeningBalance;
+                            <tr>
+                                <td>@item.User?.FullName</td>
+                                <td>@item.Account?.NameAr</td>
+                                <td>@item.Branch?.NameAr</td>
+                                <td>@item.CountedAmount.ToString("N2")</td>
+                                <td>@item.OpeningBalance.ToString("N2")</td>
+                                <td class="@(diff == 0 ? "text-success" : "text-danger")">@diff.ToString("N2")</td>
+                                <td>
+                                    <form asp-action="Approve" method="post" class="d-inline">
+                                        <input type="hidden" name="id" value="@item.Id" />
+                                        <input type="hidden" name="matched" value="true" />
+                                        <button type="submit" class="btn btn-success btn-sm">موافقة مطابقة</button>
+                                    </form>
+                                    <form asp-action="Approve" method="post" class="d-inline mt-1">
+                                        <input type="hidden" name="id" value="@item.Id" />
+                                        <input type="hidden" name="matched" value="false" />
+                                        <input type="text" name="reason" class="form-control form-control-sm d-inline w-auto" placeholder="سبب" />
+                                        <button type="submit" class="btn btn-warning btn-sm">موافقة مع فرق</button>
+                                    </form>
+                                    <form asp-action="Reject" method="post" class="d-inline mt-1">
+                                        <input type="hidden" name="id" value="@item.Id" />
+                                        <input type="text" name="reason" class="form-control form-control-sm d-inline w-auto" placeholder="سبب" />
+                                        <button type="submit" class="btn btn-danger btn-sm">رفض</button>
+                                    </form>
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            }
+            else
+            {
+                <div class="alert alert-info text-center">لا توجد طلبات حالية</div>
+            }
+        </div>
+    </div>
+</div>

--- a/AccountingSystem/Views/Dashboard/Index.cshtml
+++ b/AccountingSystem/Views/Dashboard/Index.cshtml
@@ -9,6 +9,7 @@
     var canViewStats = (await AuthorizationService.AuthorizeAsync(User, "dashboard.widget.stats")).Succeeded;
     var canViewAccounts = (await AuthorizationService.AuthorizeAsync(User, "dashboard.widget.accounts")).Succeeded;
     var canViewLinks = (await AuthorizationService.AuthorizeAsync(User, "dashboard.widget.links")).Succeeded;
+    var canViewCashBoxes = (await AuthorizationService.AuthorizeAsync(User, "dashboard.widget.cashboxes")).Succeeded;
 }
 
 <div class="container-fluid">
@@ -148,6 +149,53 @@
                             <i class="fas fa-chart-pie fa-2x"></i>
                         </div>
                     </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    }
+
+    <!-- أرصدة الصناديق -->
+    @if (canViewCashBoxes)
+    {
+    <div class="row mb-4">
+        <div class="col-12">
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="card-title mb-0">
+                        <i class="fas fa-cash-register me-2"></i>
+                        أرصدة الصناديق
+                    </h5>
+                </div>
+                <div class="card-body">
+                    @if (Model.CashBoxes.Any())
+                    {
+                        <table class="table table-bordered">
+                            <thead>
+                                <tr>
+                                    <th>الفرع</th>
+                                    <th>الحساب</th>
+                                    <th>الرصيد</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var cb in Model.CashBoxes)
+                                {
+                                    <tr>
+                                        <td>@cb.BranchName</td>
+                                        <td>@cb.AccountName</td>
+                                        <td>@cb.Balance.ToString("N2")</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    }
+                    else
+                    {
+                        <div class="alert alert-info text-center">
+                            لا توجد بيانات لعرضها
+                        </div>
+                    }
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add cash box closure entity and controller for submitting and approving cash counts
- seed permissions and integrate new cash balance widget on dashboard
- expose user cash box records with simple create and approval views

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68b255066384833398aef5b1e332843b