### PR TITLE
Add cash box closure report with export and permission

### DIFF
--- a/AccountingSystem/Data/SeedData.cs
+++ b/AccountingSystem/Data/SeedData.cs
@@ -97,7 +97,8 @@ namespace AccountingSystem.Data
                 new Permission { Name = "transfers.approve", DisplayName = "اعتماد الحوالات", Category = "الحوالات" },
                 new Permission { Name = "cashclosures.view", DisplayName = "عرض إغلاقات الصندوق", Category = "الصندوق" },
                 new Permission { Name = "cashclosures.create", DisplayName = "إنشاء إغلاق صندوق", Category = "الصندوق" },
-                new Permission { Name = "cashclosures.approve", DisplayName = "اعتماد إغلاق الصندوق", Category = "الصندوق" }
+                new Permission { Name = "cashclosures.approve", DisplayName = "اعتماد إغلاق الصندوق", Category = "الصندوق" },
+                new Permission { Name = "cashclosures.report", DisplayName = "تقرير إغلاقات الصندوق", Category = "الصندوق" }
             };
 
 

--- a/AccountingSystem/ViewModels/CashBoxClosureViewModels.cs
+++ b/AccountingSystem/ViewModels/CashBoxClosureViewModels.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace AccountingSystem.ViewModels
 {
@@ -14,5 +15,25 @@ namespace AccountingSystem.ViewModels
 
         public string AccountName { get; set; } = string.Empty;
         public string BranchName { get; set; } = string.Empty;
+    }
+
+    public class CashBoxClosureReportViewModel
+    {
+        public int? AccountId { get; set; }
+        public DateTime? FromDate { get; set; }
+        public DateTime? ToDate { get; set; }
+        public List<SelectListItem> Accounts { get; set; } = new List<SelectListItem>();
+        public List<CashBoxClosureReportItemViewModel> Closures { get; set; } = new List<CashBoxClosureReportItemViewModel>();
+    }
+
+    public class CashBoxClosureReportItemViewModel
+    {
+        public DateTime CreatedAt { get; set; }
+        public string AccountName { get; set; } = string.Empty;
+        public string BranchName { get; set; } = string.Empty;
+        public decimal OpeningBalance { get; set; }
+        public decimal CountedAmount { get; set; }
+        public decimal ClosingBalance { get; set; }
+        public string Status { get; set; } = string.Empty;
     }
 }

--- a/AccountingSystem/Views/CashBoxClosures/Report.cshtml
+++ b/AccountingSystem/Views/CashBoxClosures/Report.cshtml
@@ -1,0 +1,86 @@
+@model AccountingSystem.ViewModels.CashBoxClosureReportViewModel
+@{
+    ViewData["Title"] = "تقرير إغلاقات الصندوق";
+}
+
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">
+            <div class="card shadow">
+                <div class="card-header bg-info text-white">
+                    <h4 class="mb-0"><i class="fas fa-file-alt me-2"></i> تقرير إغلاقات الصندوق</h4>
+                </div>
+                <div class="card-body">
+                    <form method="get" class="row g-3 mb-4">
+                        <div class="col-md-4">
+                            <label class="form-label">الحساب</label>
+                            <select name="accountId" class="form-select">
+                                <option value="">كل الحسابات</option>
+                                @foreach (var acc in Model.Accounts)
+                                {
+                                    <option value="@acc.Value" @(Model.AccountId?.ToString() == acc.Value ? "selected" : "")>@acc.Text</option>
+                                }
+                            </select>
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label">من تاريخ</label>
+                            <input type="date" name="fromDate" class="form-control" value="@(Model.FromDate?.ToString("yyyy-MM-dd"))" />
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label">إلى تاريخ</label>
+                            <input type="date" name="toDate" class="form-control" value="@(Model.ToDate?.ToString("yyyy-MM-dd"))" />
+                        </div>
+                        <div class="col-md-2 d-flex align-items-end">
+                            <button type="submit" class="btn btn-info me-2"><i class="fas fa-search me-1"></i> بحث</button>
+                            @if (Model.Closures.Any())
+                            {
+                                <a class="btn btn-success" href="@Url.Action("Export", new {accountId = Model.AccountId, fromDate = Model.FromDate?.ToString("yyyy-MM-dd"), toDate = Model.ToDate?.ToString("yyyy-MM-dd")})">
+                                    <i class="fas fa-file-excel me-1"></i> تصدير
+                                </a>
+                            }
+                        </div>
+                    </form>
+
+                    <div class="table-responsive">
+                        <table class="table table-striped">
+                            <thead class="table-dark">
+                                <tr>
+                                    <th>التاريخ</th>
+                                    <th>الحساب</th>
+                                    <th>الفرع</th>
+                                    <th>الرصيد الافتتاحي</th>
+                                    <th>المبلغ المعدود</th>
+                                    <th>الرصيد الختامي</th>
+                                    <th>الحالة</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @if (Model.Closures.Any())
+                                {
+                                    foreach (var c in Model.Closures)
+                                    {
+                                        <tr>
+                                            <td>@c.CreatedAt.ToString("yyyy/MM/dd")</td>
+                                            <td>@c.AccountName</td>
+                                            <td>@c.BranchName</td>
+                                            <td class="text-end">@c.OpeningBalance.ToString("N2")</td>
+                                            <td class="text-end">@c.CountedAmount.ToString("N2")</td>
+                                            <td class="text-end">@c.ClosingBalance.ToString("N2")</td>
+                                            <td>@c.Status</td>
+                                        </tr>
+                                    }
+                                }
+                                else
+                                {
+                                    <tr>
+                                        <td colspan="7" class="text-center text-muted">لا توجد بيانات</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/AccountingSystem/Views/Shared/_AccountingLayout.cshtml
+++ b/AccountingSystem/Views/Shared/_AccountingLayout.cshtml
@@ -80,6 +80,11 @@
                                     <i class="fas fa-sitemap"></i> جرد الصندوق
                                 </a>
                             </li>
+                            <li>
+                                <a class="dropdown-item" href="@Url.Action("Report", "CashBoxClosures")">
+                                    <i class="fas fa-file-alt"></i> تقرير إغلاقات الصندوق
+                                </a>
+                            </li>
 
                             <li>
                                 <a class="dropdown-item" href="@Url.Action("Index", "Expenses")">


### PR DESCRIPTION
## Summary
- add cash box closure report with search filters and CSV export
- seed new `cashclosures.report` permission and link in navigation

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e4dd26f08333befb88e40e8d6d95