### PR TITLE
Fix cash box closure report view

### DIFF
--- a/AccountingSystem/Views/CashBoxClosures/Report.cshtml
+++ b/AccountingSystem/Views/CashBoxClosures/Report.cshtml
@@ -18,7 +18,7 @@
                                 <option value="">كل الحسابات</option>
                                 @foreach (var acc in Model.Accounts)
                                 {
-                                    <option value="@acc.Value" @(Model.AccountId?.ToString() == acc.Value ? "selected" : "")>@acc.Text</option>
+                                    <option value="@acc.Value" selected="@(Model.AccountId?.ToString() == acc.Value ? "selected" : null)">@acc.Text</option>
                                 }
                             </select>
                         </div>


### PR DESCRIPTION
## Summary
- Fix report view's account option to use Razor attribute binding for selected state

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e86733dc83339362c91e3b1f9dd4