### PR TITLE
feat: enhance cash box closure calculation

### DIFF
--- a/AccountingSystem/ViewModels/CashBoxClosureViewModels.cs
+++ b/AccountingSystem/ViewModels/CashBoxClosureViewModels.cs
@@ -15,6 +15,17 @@ namespace AccountingSystem.ViewModels
 
         public string AccountName { get; set; } = string.Empty;
         public string BranchName { get; set; } = string.Empty;
+
+        [Display(Name = "الرصيد الافتتاحي")]
+        public decimal OpeningBalance { get; set; }
+
+        [Display(Name = "حركات اليوم")]
+        public decimal TodayTransactions { get; set; }
+
+        [Display(Name = "الرصيد التراكمي")]
+        public decimal CumulativeBalance { get; set; }
+
+        public decimal Difference => CountedAmount - TodayTransactions;
     }
 
     public class CashBoxClosureReportViewModel
@@ -34,6 +45,7 @@ namespace AccountingSystem.ViewModels
         public decimal OpeningBalance { get; set; }
         public decimal CountedAmount { get; set; }
         public decimal ClosingBalance { get; set; }
+        public decimal Difference { get; set; }
         public string Status { get; set; } = string.Empty;
     }
 }

--- a/AccountingSystem/Views/CashBoxClosures/Create.cshtml
+++ b/AccountingSystem/Views/CashBoxClosures/Create.cshtml
@@ -18,11 +18,27 @@
                 <label class="form-label">الفرع</label>
                 <input type="text" class="form-control" value="@Model.BranchName" readonly />
             </div>
+            <div class="mb-3">
+                <label class="form-label">الرصيد الافتتاحي</label>
+                <input asp-for="OpeningBalance" class="form-control" readonly asp-format="{0:N2}" />
+            </div>
+            <div class="mb-3">
+                <label class="form-label">حركات اليوم</label>
+                <input asp-for="TodayTransactions" class="form-control" readonly asp-format="{0:N2}" />
+            </div>
+            <div class="mb-3">
+                <label class="form-label">الرصيد التراكمي</label>
+                <input asp-for="CumulativeBalance" class="form-control" readonly asp-format="{0:N2}" />
+            </div>
             <form asp-action="Create" method="post">
                 <div class="mb-3">
                     <label asp-for="CountedAmount" class="form-label"></label>
                     <input asp-for="CountedAmount" class="form-control" />
                     <span asp-validation-for="CountedAmount" class="text-danger"></span>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">الفرق</label>
+                    <input id="difference" type="text" class="form-control" readonly />
                 </div>
                 <div class="mb-3">
                     <label asp-for="Notes" class="form-label"></label>
@@ -36,4 +52,15 @@
 
 @section Scripts {
     @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+    <script>
+        const countedInput = document.getElementById("CountedAmount");
+        const diffInput = document.getElementById("difference");
+        const expected = @Model.TodayTransactions;
+        function updateDiff() {
+            const counted = parseFloat(countedInput.value) || 0;
+            diffInput.value = (counted - expected).toFixed(2);
+        }
+        countedInput.addEventListener("input", updateDiff);
+        updateDiff();
+    </script>
 }

--- a/AccountingSystem/Views/CashBoxClosures/Report.cshtml
+++ b/AccountingSystem/Views/CashBoxClosures/Report.cshtml
@@ -50,6 +50,7 @@
                                     <th>الفرع</th>
                                     <th>الرصيد الافتتاحي</th>
                                     <th>المبلغ المعدود</th>
+                                    <th>الفرق</th>
                                     <th>الرصيد الختامي</th>
                                     <th>الحالة</th>
                                 </tr>
@@ -65,6 +66,7 @@
                                             <td>@c.BranchName</td>
                                             <td class="text-end">@c.OpeningBalance.ToString("N2")</td>
                                             <td class="text-end">@c.CountedAmount.ToString("N2")</td>
+                                            <td class="text-end">@c.Difference.ToString("N2")</td>
                                             <td class="text-end">@c.ClosingBalance.ToString("N2")</td>
                                             <td>@c.Status</td>
                                         </tr>
@@ -73,7 +75,7 @@
                                 else
                                 {
                                     <tr>
-                                        <td colspan="7" class="text-center text-muted">لا توجد بيانات</td>
+                                        <td colspan="8" class="text-center text-muted">لا توجد بيانات</td>
                                     </tr>
                                 }
                             </tbody>


### PR DESCRIPTION
## Summary
- compute daily approved movements and show cumulative balances when closing cash boxes
- include difference between counted cash and daily movements
- limit cash box closure reports to user payment accounts

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f5c4a0bc833387eab96c5e5bb67c