### PR TITLE
Add hierarchical Income Statement report with PDF/Excel export

### DIFF
--- a/AccountingSystem/ViewModels/SimpleViewModels.cs
+++ b/AccountingSystem/ViewModels/SimpleViewModels.cs
@@ -195,8 +195,8 @@ namespace AccountingSystem.ViewModels
         public DateTime FromDate { get; set; } = new DateTime(DateTime.Now.Year, 1, 1);
         public DateTime ToDate { get; set; } = DateTime.Now;
         public int? BranchId { get; set; }
-        public List<IncomeStatementItemViewModel> Revenues { get; set; } = new List<IncomeStatementItemViewModel>();
-        public List<IncomeStatementItemViewModel> Expenses { get; set; } = new List<IncomeStatementItemViewModel>();
+        public List<AccountTreeNodeViewModel> Revenues { get; set; } = new List<AccountTreeNodeViewModel>();
+        public List<AccountTreeNodeViewModel> Expenses { get; set; } = new List<AccountTreeNodeViewModel>();
         public List<SelectListItem> Branches { get; set; } = new List<SelectListItem>();
         public decimal TotalRevenues { get; set; }
         public decimal TotalExpenses { get; set; }

--- a/AccountingSystem/Views/Reports/IncomeStatement.cshtml
+++ b/AccountingSystem/Views/Reports/IncomeStatement.cshtml
@@ -37,11 +37,20 @@
                         </div>
                         <div class="col-md-3">
                             <label class="form-label">&nbsp;</label>
-                            <div>
-                                <button type="submit" class="btn btn-success">
+                            <div class="d-flex">
+                                <button type="submit" class="btn btn-success me-2">
                                     <i class="fas fa-search me-1"></i>
                                     عرض التقرير
                                 </button>
+                                @if (Model.Revenues.Any() || Model.Expenses.Any())
+                                {
+                                    <a class="btn btn-secondary me-2" href="@Url.Action("IncomeStatementPdf", new { branchId = Model.BranchId, fromDate = Model.FromDate.ToString("yyyy-MM-dd"), toDate = Model.ToDate.ToString("yyyy-MM-dd") })">
+                                        <i class="fas fa-file-pdf me-1"></i> PDF
+                                    </a>
+                                    <a class="btn btn-success" href="@Url.Action("IncomeStatementExcel", new { branchId = Model.BranchId, fromDate = Model.FromDate.ToString("yyyy-MM-dd"), toDate = Model.ToDate.ToString("yyyy-MM-dd") })">
+                                        <i class="fas fa-file-excel me-1"></i> Excel
+                                    </a>
+                                }
                             </div>
                         </div>
                     </form>
@@ -54,12 +63,15 @@
                                     <h5 class="mb-0">الإيرادات</h5>
                                 </div>
                                 <div class="card-body">
-                                    @foreach (var revenue in Model.Revenues)
+                                    @if (Model.Revenues.Any())
                                     {
-                                        <div class="d-flex justify-content-between border-bottom py-2">
-                                            <span>@revenue.AccountName</span>
-                                            <span class="fw-bold">@revenue.Amount.ToString("N2") </span>
+                                        <div class="tree-container">
+                                            @await Html.PartialAsync("_AccountBalanceTreeNode", Model.Revenues)
                                         </div>
+                                    }
+                                    else
+                                    {
+                                        <div class="alert alert-info text-center">لا توجد بيانات</div>
                                     }
                                     <div class="d-flex justify-content-between border-top pt-3 mt-3">
                                         <strong>إجمالي الإيرادات:</strong>
@@ -74,12 +86,15 @@
                                     <h5 class="mb-0">المصروفات</h5>
                                 </div>
                                 <div class="card-body">
-                                    @foreach (var expense in Model.Expenses)
+                                    @if (Model.Expenses.Any())
                                     {
-                                        <div class="d-flex justify-content-between border-bottom py-2">
-                                            <span>@expense.AccountName</span>
-                                            <span class="fw-bold">@expense.Amount.ToString("N2") </span>
+                                        <div class="tree-container">
+                                            @await Html.PartialAsync("_AccountBalanceTreeNode", Model.Expenses)
                                         </div>
+                                    }
+                                    else
+                                    {
+                                        <div class="alert alert-info text-center">لا توجد بيانات</div>
                                     }
                                     <div class="d-flex justify-content-between border-top pt-3 mt-3">
                                         <strong>إجمالي المصروفات:</strong>
@@ -102,7 +117,7 @@
                                         <span>إجمالي المصروفات</span>
                                         <span class="fw-bold text-danger">@Model.TotalExpenses.ToString("N2") </span>
                                     </div>
-                                    <hr>
+                                    <hr />
                                     <div class="d-flex justify-content-between">
                                         <strong class="fs-5">صافي الدخل:</strong>
                                         <strong class="fs-5 text-primary">@Model.NetIncome.ToString("N2") </strong>
@@ -116,3 +131,82 @@
         </div>
     </div>
 </div>
+
+@section Styles {
+    <style>
+        .tree-container {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+        }
+
+        .tree-node {
+            margin: 5px 0;
+            padding: 8px;
+            border-radius: 5px;
+        }
+
+        .tree-node-content {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+        }
+
+        .tree-node-info {
+            display: flex;
+            align-items: center;
+            flex-grow: 1;
+        }
+
+        .tree-children {
+            margin-right: 25px;
+            border-right: 2px solid #e9ecef;
+            padding-right: 15px;
+        }
+
+        .account-code {
+            font-weight: bold;
+            color: #495057;
+            margin-left: 10px;
+        }
+
+        .account-name {
+            color: #212529;
+            margin-left: 10px;
+        }
+
+        .toggle-btn {
+            background: none;
+            border: none;
+            color: #6c757d;
+            cursor: pointer;
+            padding: 0;
+            margin-left: 5px;
+            width: 20px;
+            text-align: center;
+        }
+
+            .toggle-btn:hover {
+                color: #495057;
+            }
+    </style>
+}
+
+@section Scripts {
+    <script>
+        $(function () {
+            $('.toggle-btn').on('click', function () {
+                var $this = $(this);
+                var $children = $this.closest('.tree-node').find('> .tree-children');
+                if ($children.is(':visible')) {
+                    $children.hide();
+                    $this.html('<i class="fas fa-plus"></i>');
+                } else {
+                    $children.show();
+                    $this.html('<i class="fas fa-minus"></i>');
+                }
+            });
+        });
+        $(document).ready(function () {
+            $('.tree-node[data-level="0"] .toggle-btn').click();
+        });
+    </script>
+}


### PR DESCRIPTION
## Summary
- generate Income Statement from account tree with computed balances
- allow exporting Income Statement to PDF and Excel
- show revenue and expense hierarchies in the report view

## Testing
- `dotnet build` *(fails: NETSDK1045: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b6058854788333af64796d89a875e1