### PR TITLE
Add search functionality to navigation dropdowns

### DIFF
--- a/AccountingSystem/Views/Reports/AccountStatement.cshtml
+++ b/AccountingSystem/Views/Reports/AccountStatement.cshtml
@@ -3,6 +3,10 @@
     ViewData["Title"] = "كشف الحساب";
 }
 
+@section Styles {
+    <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+}
+
 <div class="container-fluid">
     <div class="row">
         <div class="col-12">
@@ -18,7 +22,7 @@
                     <form method="get" class="row g-3 mb-4">
                         <div class="col-md-3">
                             <label for="accountId" class="form-label">الحساب:</label>
-                            <select name="accountId" id="accountId" class="form-select" required>
+                            <select name="accountId" id="accountId" class="form-select account-select" required>
                                 <option value="">اختر الحساب</option>
                                 @if (Model?.Accounts != null)
                                 {
@@ -182,3 +186,13 @@
         </div>
     </div>
 </div>
+
+@section Scripts {
+    <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+    <script>
+        $('#accountId').select2({
+            placeholder: 'اختر الحساب',
+            width: '100%'
+        });
+    </script>
+}

--- a/AccountingSystem/Views/Shared/_AccountingLayout.cshtml
+++ b/AccountingSystem/Views/Shared/_AccountingLayout.cshtml
@@ -135,34 +135,37 @@
                         <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">
                             <i class="fas fa-chart-bar"></i> التقارير
                         </a>
-                        <ul class="dropdown-menu">
-                            <li>
+                        <ul class="dropdown-menu" id="reportsDropdown">
+                            <li class="px-3">
+                                <input type="text" class="form-control" id="reportSearch" placeholder="ابحث عن تقرير...">
+                            </li>
+                            <li class="report-item">
                                 <a class="dropdown-item" href="@Url.Action("TrialBalance", "Reports")">
                                     <i class="fas fa-balance-scale"></i> ميزان المراجعة
                                 </a>
                             </li>
-                            <li>
+                            <li class="report-item">
                                 <a class="dropdown-item" href="@Url.Action("BalanceSheet", "Reports")">
                                     <i class="fas fa-chart-pie"></i> الميزانية العمومية
                                 </a>
                             </li>
-                            <li>
+                            <li class="report-item">
                                 <a class="dropdown-item" href="@Url.Action("IncomeStatement", "Reports")">
                                     <i class="fas fa-chart-line"></i> قائمة الدخل
                                 </a>
                             </li>
-                            <li><hr class="dropdown-divider"></li>
-                            <li>
+                            <li class="report-item"><hr class="dropdown-divider"></li>
+                            <li class="report-item">
                                 <a class="dropdown-item" href="@Url.Action("GeneralLedger", "Reports")">
                                     <i class="fas fa-book"></i> دفتر الأستاذ العام
                                 </a>
                             </li>
-                            <li>
+                            <li class="report-item">
                                 <a class="dropdown-item" href="@Url.Action("AccountStatement", "Reports")">
                                     <i class="fas fa-file-alt"></i> كشف حساب
                                 </a>
                             </li>
-                            <li>
+                            <li class="report-item">
                                 <a class="dropdown-item" href="@Url.Action("PendingTransactions", "Reports")">
                                     <i class="fas fa-hourglass-half"></i> الحركات غير المرحلة
                                 </a>
@@ -327,6 +330,14 @@
                         $('input[name="__RequestVerificationToken"]').val());
                 }
             }
+        });
+
+        // Reports dropdown search filter
+        $('#reportSearch').on('input', function () {
+            var value = $(this).val().toLowerCase();
+            $('#reportsDropdown li.report-item').each(function () {
+                $(this).toggle($(this).text().toLowerCase().indexOf(value) > -1);
+            });
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- allow filtering report links by adding a search field to the Reports navigation dropdown
- enable searching accounts on the Account Statement page via Select2-enhanced dropdown

## Testing
- `dotnet test AccountingSystem/AccountingSystem.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b7443c90fc8333b4fa09113b4a1c75