### PR TITLE
Add account management navigation with permissions

### DIFF
--- a/AccountingSystem/Controllers/AccountManagementController.cs
+++ b/AccountingSystem/Controllers/AccountManagementController.cs
@@ -8,6 +8,7 @@ using Syncfusion.EJ2.Base;
 using System.Data;
 using System.Security.Claims;
 using System.Text;
+using Microsoft.AspNetCore.Authorization;
 
 namespace Roadfn.Controllers
 {
@@ -24,6 +25,7 @@ namespace Roadfn.Controllers
             this.iConfig = iConfig;
         }
 
+        [Authorize(Policy = "accountmanagement.driverstatment")]
         public async Task<IActionResult> DriverStatment()
         {
             ViewBag.CompanyBranches = await _context.CompanyBranches.ToListAsync();
@@ -39,6 +41,7 @@ namespace Roadfn.Controllers
             return View();
         }
 
+        [Authorize(Policy = "accountmanagement.busnissstatment")]
         public async Task<IActionResult> BusnissStatment()
         {
             ViewBag.Driver = from t1 in _context.Users
@@ -56,6 +59,7 @@ namespace Roadfn.Controllers
             ViewBag.CompanyBranches = await _context.CompanyBranches.ToListAsync();
             return View();
         }
+        [Authorize(Policy = "accountmanagement.busnissshipmentsreturn")]
         public async Task<IActionResult> BusnissShipmentsReturn()
         {
             ViewBag.Driver = from t1 in _context.Users
@@ -158,6 +162,7 @@ namespace Roadfn.Controllers
             return Json(Data);
         }
 
+        [Authorize(Policy = "accountmanagement.receivepayments")]
         public IActionResult ReceivePayments()
         {
             ViewBag.Driver = from t1 in _context.Users
@@ -167,7 +172,8 @@ namespace Roadfn.Controllers
 
             return View();
         }
-        public async Task<IActionResult> ReceiveRetPaymentsAsync()
+        [Authorize(Policy = "accountmanagement.receiveretpayments")]
+        public async Task<IActionResult> ReceiveRetPayments()
         {
             ViewBag.Driver = from t1 in _context.Users
                              where t1.UserType == "4"
@@ -499,6 +505,7 @@ namespace Roadfn.Controllers
             return dm.RequiresCounts ? Json(new { result = DataSource, count = count }) : Json(DataSource);
         }
 
+        [Authorize(Policy = "accountmanagement.businessstatementbulk")]
         public async Task<IActionResult> BusinessStatementBulk()
         {
             ViewBag.Driver = from t1 in _context.Users
@@ -516,6 +523,7 @@ namespace Roadfn.Controllers
             ViewBag.CompanyBranches = await _context.CompanyBranches.ToListAsync();
             return View();
         }
+        [Authorize(Policy = "accountmanagement.businessretstatementbulk")]
         public async Task<IActionResult> BusinessRetStatementBulk()
         {
             ViewBag.Driver = from t1 in _context.Users
@@ -535,6 +543,7 @@ namespace Roadfn.Controllers
         }
 
 
+        [Authorize(Policy = "accountmanagement.driverpayment")]
         public async Task<IActionResult> DriverPayment()
         {
             var t = from c in _context.Drives
@@ -547,6 +556,7 @@ namespace Roadfn.Controllers
             return View();
         }
 
+        [Authorize(Policy = "accountmanagement.userpayment")]
         public async Task<IActionResult> UserPayment()
         {
             //ViewBag.city = await _context.Cities.ToListAsync();
@@ -554,6 +564,13 @@ namespace Roadfn.Controllers
                        where u.UserType == "3"
                        select new { u.Id, UserName = u.FirstName + " " + u.LastName };
             ViewBag.user = await user.ToListAsync();
+            return View();
+        }
+
+        [HttpGet]
+        [Authorize(Policy = "accountmanagement.printslip")]
+        public IActionResult PrintSlip()
+        {
             return View();
         }
 
@@ -1640,6 +1657,7 @@ namespace Roadfn.Controllers
 
 
         [HttpGet]
+        [Authorize(Policy = "accountmanagement.printslip")]
         public async Task<IActionResult> PrintDriverSlip(string Id)
         {
             var ids = Id.Split(",");
@@ -1729,6 +1747,7 @@ namespace Roadfn.Controllers
         }
 
         [HttpGet]
+        [Authorize(Policy = "accountmanagement.printslip")]
         public async Task<IActionResult> PrintUserSlip(string Id)
         {
             //var ids = Id.Split(",");

--- a/AccountingSystem/Views/AccountManagement/BusinessRetStatementBulk.cshtml
+++ b/AccountingSystem/Views/AccountManagement/BusinessRetStatementBulk.cshtml
@@ -1,11 +1,8 @@
 ﻿@{
     var rtl = true;
-}
-@{
     var delete = true;
-
+    ViewData["Title"] = "اصدار كلي لفاتورة طرود مرتجعه";
 }
-<title>اصدار كلي لفاتورة طرود مرتجعه - roadfn </title>
 
 <div class="container-full">
     <!-- Content Header (Page header) -->

--- a/AccountingSystem/Views/AccountManagement/BusinessStatementBulk.cshtml
+++ b/AccountingSystem/Views/AccountManagement/BusinessStatementBulk.cshtml
@@ -1,11 +1,8 @@
 ﻿@{
     var rtl = true;
-}
-@{
     var delete = true;
-
+    ViewData["Title"] = "حساب العميل كلي";
 }
-<title>حساب العميل - roadfn </title>
 
 <div class="container-full">
     <!-- Content Header (Page header) -->

--- a/AccountingSystem/Views/AccountManagement/BusnissShipmentsReturn.cshtml
+++ b/AccountingSystem/Views/AccountManagement/BusnissShipmentsReturn.cshtml
@@ -3,9 +3,8 @@
 
 @{
     var rtl = true;
+    ViewData["Title"] = "اغلاق طرود مرتجعه";
 }
-
-<title>اغلاق طرود مرتجعه - roadfn </title>
 
 <div class="container-full">
     <!-- Content Header (Page header) -->

--- a/AccountingSystem/Views/AccountManagement/BusnissStatment.cshtml
+++ b/AccountingSystem/Views/AccountManagement/BusnissStatment.cshtml
@@ -1,14 +1,10 @@
 ﻿@using Newtonsoft.Json
 
-
 @{
     var rtl = true;
-
     ViewData["Title"] = "حساب العميل";
-
 }
 
-<title>حساب العميل - roadfn </title>
 
 <div class="container-full">
 

--- a/AccountingSystem/Views/AccountManagement/DriverPayment.cshtml
+++ b/AccountingSystem/Views/AccountManagement/DriverPayment.cshtml
@@ -1,7 +1,7 @@
 ﻿@{
     var rtl = true;
+    ViewData["Title"] = "دفعات السائق";
 }
-<title>دفعات السائق - roadfn </title>
 
 <div class="container-full">
     <!-- Content Header (Page header) -->

--- a/AccountingSystem/Views/AccountManagement/DriverStatment.cshtml
+++ b/AccountingSystem/Views/AccountManagement/DriverStatment.cshtml
@@ -3,9 +3,8 @@
 @{
     var rtl = true;
     ViewData["Title"] = "حساب سائق";
-
 }
-<title>Driver Statment - roadfn </title>
+
 
 <div class="container-full" id="mains">
 

--- a/AccountingSystem/Views/AccountManagement/PrintSlip.cshtml
+++ b/AccountingSystem/Views/AccountManagement/PrintSlip.cshtml
@@ -1,6 +1,7 @@
 ﻿
 @{
     Layout = null;
+    ViewData["Title"] = "طباعة ايصال";
 }
 
     @Html.Raw(@ViewBag.report);

--- a/AccountingSystem/Views/AccountManagement/ReceivePayments.cshtml
+++ b/AccountingSystem/Views/AccountManagement/ReceivePayments.cshtml
@@ -1,7 +1,7 @@
 ﻿@{
     var rtl = true;
+    ViewData["Title"] = "تسليم فواتير";
 }
-<title>تسليم فواتير - roadfn </title>
 
 <div class="container-full">
     <!-- Content Header (Page header) -->

--- a/AccountingSystem/Views/AccountManagement/ReceiveRetPayments.cshtml
+++ b/AccountingSystem/Views/AccountManagement/ReceiveRetPayments.cshtml
@@ -1,7 +1,7 @@
 ﻿@{
     var rtl = true;
+    ViewData["Title"] = "تسليم فواتير طرود مرتجعه";
 }
-<title>تسليم فواتير طرود مرتجعه - roadfn </title>
 
 <div class="container-full">
     <!-- Content Header (Page header) -->

--- a/AccountingSystem/Views/AccountManagement/UserPayment.cshtml
+++ b/AccountingSystem/Views/AccountManagement/UserPayment.cshtml
@@ -1,7 +1,7 @@
 ﻿@{
     var rtl = true;
+    ViewData["Title"] = "دفعات العميل";
 }
-<title>دفعات العميل - roadfn </title>
 
 <div class="container-full">
     <!-- Content Header (Page header) -->

--- a/AccountingSystem/Views/Shared/_AccountingLayout.cshtml
+++ b/AccountingSystem/Views/Shared/_AccountingLayout.cshtml
@@ -1,3 +1,5 @@
+@using Microsoft.AspNetCore.Authorization
+@inject IAuthorizationService AuthorizationService
 <!DOCTYPE html>
 <html lang="ar" dir="rtl">
 <head>
@@ -17,6 +19,19 @@
     @await RenderSectionAsync("Styles", required: false)
 </head>
 <body>
+@{
+    var canBusinessStatementBulk = (await AuthorizationService.AuthorizeAsync(User, "accountmanagement.businessstatementbulk")).Succeeded;
+    var canBusinessRetStatementBulk = (await AuthorizationService.AuthorizeAsync(User, "accountmanagement.businessretstatementbulk")).Succeeded;
+    var canBusnissShipmentsReturn = (await AuthorizationService.AuthorizeAsync(User, "accountmanagement.busnissshipmentsreturn")).Succeeded;
+    var canBusnissStatment = (await AuthorizationService.AuthorizeAsync(User, "accountmanagement.busnissstatment")).Succeeded;
+    var canDriverPayment = (await AuthorizationService.AuthorizeAsync(User, "accountmanagement.driverpayment")).Succeeded;
+    var canDriverStatment = (await AuthorizationService.AuthorizeAsync(User, "accountmanagement.driverstatment")).Succeeded;
+    var canPrintSlip = (await AuthorizationService.AuthorizeAsync(User, "accountmanagement.printslip")).Succeeded;
+    var canReceivePayments = (await AuthorizationService.AuthorizeAsync(User, "accountmanagement.receivepayments")).Succeeded;
+    var canReceiveRetPayments = (await AuthorizationService.AuthorizeAsync(User, "accountmanagement.receiveretpayments")).Succeeded;
+    var canUserPayment = (await AuthorizationService.AuthorizeAsync(User, "accountmanagement.userpayment")).Succeeded;
+    var showAccountManagement = canBusinessStatementBulk || canBusinessRetStatementBulk || canBusnissShipmentsReturn || canBusnissStatment || canDriverPayment || canDriverStatment || canPrintSlip || canReceivePayments || canReceiveRetPayments || canUserPayment;
+}
     <!-- Top Navigation -->
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
         <div class="container-fluid">
@@ -102,7 +117,58 @@
                     </li>
 
 
-                    <!-- Journal Entries Dropdown -->
+    
+                @if (showAccountManagement)
+                {
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">
+                            <i class="fas fa-briefcase"></i> إدارة الحسابات
+                        </a>
+                        <ul class="dropdown-menu">
+                            @if (canBusinessRetStatementBulk)
+                            {
+                                <li><a class="dropdown-item" href="@Url.Action("BusinessRetStatementBulk", "AccountManagement")">اصدار كلي لفاتورة طرود مرتجعه</a></li>
+                            }
+                            @if (canBusinessStatementBulk)
+                            {
+                                <li><a class="dropdown-item" href="@Url.Action("BusinessStatementBulk", "AccountManagement")">حساب العميل كلي</a></li>
+                            }
+                            @if (canBusnissShipmentsReturn)
+                            {
+                                <li><a class="dropdown-item" href="@Url.Action("BusnissShipmentsReturn", "AccountManagement")">اغلاق طرود مرتجعه</a></li>
+                            }
+                            @if (canBusnissStatment)
+                            {
+                                <li><a class="dropdown-item" href="@Url.Action("BusnissStatment", "AccountManagement")">حساب العميل</a></li>
+                            }
+                            @if (canDriverPayment)
+                            {
+                                <li><a class="dropdown-item" href="@Url.Action("DriverPayment", "AccountManagement")">دفعات السائق</a></li>
+                            }
+                            @if (canDriverStatment)
+                            {
+                                <li><a class="dropdown-item" href="@Url.Action("DriverStatment", "AccountManagement")">حساب السائق</a></li>
+                            }
+                            @if (canPrintSlip)
+                            {
+                                <li><a class="dropdown-item" href="@Url.Action("PrintSlip", "AccountManagement")">طباعة ايصال</a></li>
+                            }
+                            @if (canReceivePayments)
+                            {
+                                <li><a class="dropdown-item" href="@Url.Action("ReceivePayments", "AccountManagement")">تسليم فواتير</a></li>
+                            }
+                            @if (canReceiveRetPayments)
+                            {
+                                <li><a class="dropdown-item" href="@Url.Action("ReceiveRetPayments", "AccountManagement")">تسليم فواتير طرود مرتجعه</a></li>
+                            }
+                            @if (canUserPayment)
+                            {
+                                <li><a class="dropdown-item" href="@Url.Action("UserPayment", "AccountManagement")">دفعات العميل</a></li>
+                            }
+                        </ul>
+                    </li>
+                }
+                <!-- Journal Entries Dropdown -->
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">
                             <i class="fas fa-file-invoice"></i> القيود المالية


### PR DESCRIPTION
## Summary
- localize account management dropdown links
- set page titles for account management views

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b75ac948888333b180926e1de91f90