### PR TITLE
Add currency-aware balances to dashboard

### DIFF
--- a/AccountingSystem/Controllers/DashboardController.cs
+++ b/AccountingSystem/Controllers/DashboardController.cs
@@ -7,6 +7,7 @@ using AccountingSystem.ViewModels;
 using System.Linq;
 using System.Collections.Generic;
 using System.Security.Claims;
+using AccountingSystem.Services;
 
 namespace AccountingSystem.Controllers
 {
@@ -15,14 +16,16 @@ namespace AccountingSystem.Controllers
     {
         private readonly ApplicationDbContext _context;
         private readonly ILogger<DashboardController> _logger;
+        private readonly ICurrencyService _currencyService;
 
-        public DashboardController(ApplicationDbContext context, ILogger<DashboardController> logger)
+        public DashboardController(ApplicationDbContext context, ILogger<DashboardController> logger, ICurrencyService currencyService)
         {
             _context = context;
             _logger = logger;
+            _currencyService = currencyService;
         }
 
-        public async Task<IActionResult> Index(int? branchId = null, DateTime? fromDate = null, DateTime? toDate = null)
+        public async Task<IActionResult> Index(int? branchId = null, DateTime? fromDate = null, DateTime? toDate = null, int? currencyId = null)
         {
             var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
             var userBranchIds = await _context.UserBranches
@@ -45,8 +48,13 @@ namespace AccountingSystem.Controllers
                 .Where(a => !allowedBranchIds.Any() || a.BranchId == null || allowedBranchIds.Contains(a.BranchId.Value))
                 .Include(a => a.JournalEntryLines)
                     .ThenInclude(l => l.JournalEntry)
+                .Include(a => a.Currency)
                 .AsNoTracking()
                 .ToListAsync();
+
+            var baseCurrency = await _context.Currencies.FirstAsync(c => c.IsBase);
+            var selectedCurrency = currencyId.HasValue ? await _context.Currencies.FirstOrDefaultAsync(c => c.Id == currencyId.Value) : baseCurrency;
+            selectedCurrency ??= baseCurrency;
 
             var accountBalances = accounts.ToDictionary(a => a.Id, a =>
                 a.OpeningBalance + a.JournalEntryLines
@@ -59,7 +67,9 @@ namespace AccountingSystem.Controllers
                 {
                     AccountName = a.NameAr,
                     BranchName = a.Branch?.NameAr ?? string.Empty,
-                    Balance = accountBalances[a.Id]
+                    Balance = accountBalances[a.Id],
+                    BalanceSelected = _currencyService.Convert(accountBalances[a.Id], a.Currency, selectedCurrency),
+                    BalanceBase = _currencyService.Convert(accountBalances[a.Id], a.Currency, baseCurrency)
                 })
                 .ToList();
 
@@ -72,6 +82,8 @@ namespace AccountingSystem.Controllers
                 Nature = a.Nature,
                 OpeningBalance = a.OpeningBalance,
                 Balance = accountBalances[a.Id],
+                BalanceSelected = _currencyService.Convert(accountBalances[a.Id], a.Currency, selectedCurrency),
+                BalanceBase = _currencyService.Convert(accountBalances[a.Id], a.Currency, baseCurrency),
                 IsActive = a.IsActive,
                 CanPostTransactions = a.CanPostTransactions,
                 ParentId = a.ParentId,
@@ -89,19 +101,24 @@ namespace AccountingSystem.Controllers
                 }
             }
 
-            decimal ComputeBalance(AccountTreeNodeViewModel node)
+            void ComputeBalances(AccountTreeNodeViewModel node)
             {
+                foreach (var child in node.Children)
+                {
+                    ComputeBalances(child);
+                }
                 if (node.Children.Any())
                 {
-                    node.Balance = node.Children.Sum(ComputeBalance);
+                    node.Balance = node.Children.Sum(c => c.Balance);
+                    node.BalanceSelected = node.Children.Sum(c => c.BalanceSelected);
+                    node.BalanceBase = node.Children.Sum(c => c.BalanceBase);
                 }
-                return node.Balance;
             }
 
             var rootNodes = nodes.Values.Where(n => n.ParentId == null).ToList();
             foreach (var root in rootNodes)
             {
-                ComputeBalance(root);
+                ComputeBalances(root);
             }
 
             var accountTypeTrees = rootNodes
@@ -113,31 +130,46 @@ namespace AccountingSystem.Controllers
                     AccountType = g.Key,
                     Level = 0,
                     Balance = g.Sum(n => n.Balance),
+                    BalanceSelected = g.Sum(n => n.BalanceSelected),
+                    BalanceBase = g.Sum(n => n.BalanceBase),
                     Children = g.OrderBy(n => n.Code).ToList(),
                     HasChildren = g.Any()
                 }).ToList();
 
-            var totals = accountTypeTrees.ToDictionary(n => n.AccountType, n => n.Balance);
+            var totals = accountTypeTrees.ToDictionary(n => n.AccountType, n => (n.BalanceSelected, n.BalanceBase));
 
             var viewModel = new DashboardViewModel
             {
                 SelectedBranchId = branchId,
+                SelectedCurrencyId = selectedCurrency.Id,
+                SelectedCurrencyCode = selectedCurrency.Code,
+                BaseCurrencyCode = baseCurrency.Code,
                 FromDate = startDate,
                 ToDate = endDate,
-                TotalAssets = totals.ContainsKey(AccountType.Assets) ? totals[AccountType.Assets] : 0,
-                TotalLiabilities = totals.ContainsKey(AccountType.Liabilities) ? totals[AccountType.Liabilities] : 0,
-                TotalEquity = totals.ContainsKey(AccountType.Equity) ? totals[AccountType.Equity] : 0,
-                TotalRevenues = totals.ContainsKey(AccountType.Revenue) ? totals[AccountType.Revenue] : 0,
-                TotalExpenses = totals.ContainsKey(AccountType.Expenses) ? totals[AccountType.Expenses] : 0,
+                TotalAssets = totals.ContainsKey(AccountType.Assets) ? totals[AccountType.Assets].Item1 : 0,
+                TotalLiabilities = totals.ContainsKey(AccountType.Liabilities) ? totals[AccountType.Liabilities].Item1 : 0,
+                TotalEquity = totals.ContainsKey(AccountType.Equity) ? totals[AccountType.Equity].Item1 : 0,
+                TotalRevenues = totals.ContainsKey(AccountType.Revenue) ? totals[AccountType.Revenue].Item1 : 0,
+                TotalExpenses = totals.ContainsKey(AccountType.Expenses) ? totals[AccountType.Expenses].Item1 : 0,
+                TotalAssetsBase = totals.ContainsKey(AccountType.Assets) ? totals[AccountType.Assets].Item2 : 0,
+                TotalLiabilitiesBase = totals.ContainsKey(AccountType.Liabilities) ? totals[AccountType.Liabilities].Item2 : 0,
+                TotalEquityBase = totals.ContainsKey(AccountType.Equity) ? totals[AccountType.Equity].Item2 : 0,
+                TotalRevenuesBase = totals.ContainsKey(AccountType.Revenue) ? totals[AccountType.Revenue].Item2 : 0,
+                TotalExpensesBase = totals.ContainsKey(AccountType.Expenses) ? totals[AccountType.Expenses].Item2 : 0,
                 AccountTypeTrees = accountTypeTrees,
                 CashBoxes = cashBoxes
             };
 
             viewModel.NetIncome = viewModel.TotalRevenues - viewModel.TotalExpenses;
+            viewModel.NetIncomeBase = viewModel.TotalRevenuesBase - viewModel.TotalExpensesBase;
 
             ViewBag.Branches = await _context.Branches
                 .Where(b => b.IsActive && userBranchIds.Contains(b.Id))
                 .Select(b => new { b.Id, b.NameAr })
+                .ToListAsync();
+
+            ViewBag.Currencies = await _context.Currencies
+                .Select(c => new { c.Id, c.Code })
                 .ToListAsync();
 
             return View(viewModel);

--- a/AccountingSystem/Program.cs
+++ b/AccountingSystem/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Roadfn.Services;
 using Microsoft.Extensions.Configuration;
 using System.Text.Json.Serialization;
+using AccountingSystem.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -59,6 +60,7 @@ builder.Services.AddControllersWithViews().AddNewtonsoftJson(options =>
 builder.Services.AddHttpContextAccessor();
 
 builder.Services.AddScoped<UserResolverService>();
+builder.Services.AddScoped<ICurrencyService, CurrencyService>();
 
 builder.Services.AddSingleton<IAuthorizationPolicyProvider, PermissionPolicyProvider>();
 builder.Services.AddScoped<IAuthorizationHandler, PermissionHandler>();

--- a/AccountingSystem/Services/CurrencyService.cs
+++ b/AccountingSystem/Services/CurrencyService.cs
@@ -1,0 +1,18 @@
+using AccountingSystem.Models;
+
+namespace AccountingSystem.Services
+{
+    public class CurrencyService : ICurrencyService
+    {
+        public decimal Convert(decimal amount, Currency fromCurrency, Currency toCurrency)
+        {
+            if (fromCurrency == null || toCurrency == null)
+                throw new ArgumentNullException();
+            if (fromCurrency.Id == toCurrency.Id)
+                return amount;
+            if (toCurrency.ExchangeRate == 0)
+                return 0;
+            return amount * fromCurrency.ExchangeRate / toCurrency.ExchangeRate;
+        }
+    }
+}

--- a/AccountingSystem/Services/ICurrencyService.cs
+++ b/AccountingSystem/Services/ICurrencyService.cs
@@ -1,0 +1,9 @@
+using AccountingSystem.Models;
+
+namespace AccountingSystem.Services
+{
+    public interface ICurrencyService
+    {
+        decimal Convert(decimal amount, Currency fromCurrency, Currency toCurrency);
+    }
+}

--- a/AccountingSystem/ViewModels/SimpleViewModels.cs
+++ b/AccountingSystem/ViewModels/SimpleViewModels.cs
@@ -278,6 +278,8 @@ namespace AccountingSystem.ViewModels
         public string BranchName { get; set; } = string.Empty;
         public string AccountName { get; set; } = string.Empty;
         public decimal Balance { get; set; }
+        public decimal BalanceSelected { get; set; }
+        public decimal BalanceBase { get; set; }
     }
 
     public class DashboardViewModel
@@ -292,7 +294,16 @@ namespace AccountingSystem.ViewModels
         public decimal TotalRevenues { get; set; }
         public decimal TotalExpenses { get; set; }
         public decimal NetIncome { get; set; }
+        public decimal TotalAssetsBase { get; set; }
+        public decimal TotalLiabilitiesBase { get; set; }
+        public decimal TotalEquityBase { get; set; }
+        public decimal TotalRevenuesBase { get; set; }
+        public decimal TotalExpensesBase { get; set; }
+        public decimal NetIncomeBase { get; set; }
         public int? SelectedBranchId { get; set; }
+        public int? SelectedCurrencyId { get; set; }
+        public string SelectedCurrencyCode { get; set; } = string.Empty;
+        public string BaseCurrencyCode { get; set; } = string.Empty;
         public DateTime FromDate { get; set; } = DateTime.Today;
         public DateTime ToDate { get; set; } = DateTime.Today;
         public List<SelectListItem> Branches { get; set; } = new List<SelectListItem>();
@@ -327,6 +338,8 @@ namespace AccountingSystem.ViewModels
         public decimal OpeningBalance { get; set; }
         public decimal CurrentBalance { get; set; }
         public decimal Balance { get; set; }
+        public decimal BalanceSelected { get; set; }
+        public decimal BalanceBase { get; set; }
         public bool IsActive { get; set; }
         public bool CanPostTransactions { get; set; }
         public int? ParentId { get; set; }

--- a/AccountingSystem/Views/Dashboard/Index.cshtml
+++ b/AccountingSystem/Views/Dashboard/Index.cshtml
@@ -47,6 +47,19 @@
                             <label for="toDateFilter" class="form-label">إلى تاريخ:</label>
                             <input type="date" id="toDateFilter" class="form-control" value="@Model.ToDate.ToString("yyyy-MM-dd")" onchange="applyFilters()" />
                         </div>
+                        <div class="col-md-3 mb-3">
+                            <label for="currencyFilter" class="form-label">العملة:</label>
+                            <select id="currencyFilter" class="form-select" onchange="applyFilters()">
+                                <option value="">@Model.BaseCurrencyCode</option>
+                                @if (ViewBag.Currencies != null)
+                                {
+                                    @foreach (var currency in ViewBag.Currencies)
+                                    {
+                                        <option value="@currency.Id" selected="@(Model.SelectedCurrencyId == currency.Id ? "selected" : null)">@currency.Code</option>
+                                    }
+                                }
+                            </select>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -63,7 +76,7 @@
                     <div class="d-flex justify-content-between">
                         <div>
                             <h6 class="card-title">إجمالي الأصول</h6>
-                            <h4 class="mb-0">@Model.TotalAssets.ToString("N0")</h4>
+                            <h4 class="mb-0">@Model.TotalAssets.ToString("N0") @Model.SelectedCurrencyCode <small class="text-muted">(@Model.TotalAssetsBase.ToString("N0") @Model.BaseCurrencyCode)</small></h4>
                         </div>
                         <div class="align-self-center">
                             <i class="fas fa-chart-line fa-2x"></i>
@@ -79,7 +92,7 @@
                     <div class="d-flex justify-content-between">
                         <div>
                             <h6 class="card-title">إجمالي الخصوم</h6>
-                            <h4 class="mb-0">@Model.TotalLiabilities.ToString("N0")</h4>
+                            <h4 class="mb-0">@Model.TotalLiabilities.ToString("N0") @Model.SelectedCurrencyCode <small class="text-muted">(@Model.TotalLiabilitiesBase.ToString("N0") @Model.BaseCurrencyCode)</small></h4>
                         </div>
                         <div class="align-self-center">
                             <i class="fas fa-balance-scale fa-2x"></i>
@@ -95,7 +108,7 @@
                     <div class="d-flex justify-content-between">
                         <div>
                             <h6 class="card-title">إجمالي حقوق الملكية</h6>
-                            <h4 class="mb-0">@Model.TotalEquity.ToString("N0")</h4>
+                            <h4 class="mb-0">@Model.TotalEquity.ToString("N0") @Model.SelectedCurrencyCode <small class="text-muted">(@Model.TotalEquityBase.ToString("N0") @Model.BaseCurrencyCode)</small></h4>
                         </div>
                         <div class="align-self-center">
                             <i class="fas fa-university fa-2x"></i>
@@ -111,7 +124,7 @@
                     <div class="d-flex justify-content-between">
                         <div>
                             <h6 class="card-title">إجمالي الإيرادات</h6>
-                            <h4 class="mb-0">@Model.TotalRevenues.ToString("N0")</h4>
+                            <h4 class="mb-0">@Model.TotalRevenues.ToString("N0") @Model.SelectedCurrencyCode <small class="text-muted">(@Model.TotalRevenuesBase.ToString("N0") @Model.BaseCurrencyCode)</small></h4>
                         </div>
                         <div class="align-self-center">
                             <i class="fas fa-dollar-sign fa-2x"></i>
@@ -127,7 +140,7 @@
                     <div class="d-flex justify-content-between">
                         <div>
                             <h6 class="card-title">إجمالي المصروفات</h6>
-                            <h4 class="mb-0">@Model.TotalExpenses.ToString("N0")</h4>
+                            <h4 class="mb-0">@Model.TotalExpenses.ToString("N0") @Model.SelectedCurrencyCode <small class="text-muted">(@Model.TotalExpensesBase.ToString("N0") @Model.BaseCurrencyCode)</small></h4>
                         </div>
                         <div class="align-self-center">
                             <i class="fas fa-shopping-cart fa-2x"></i>
@@ -143,7 +156,7 @@
                     <div class="d-flex justify-content-between">
                         <div>
                             <h6 class="card-title">صافي الربح</h6>
-                            <h4 class="mb-0">@Model.NetIncome.ToString("N0")</h4>
+                            <h4 class="mb-0">@Model.NetIncome.ToString("N0") @Model.SelectedCurrencyCode <small class="text-muted">(@Model.NetIncomeBase.ToString("N0") @Model.BaseCurrencyCode)</small></h4>
                         </div>
                         <div class="align-self-center">
                             <i class="fas fa-chart-pie fa-2x"></i>
@@ -175,7 +188,9 @@
                                 <tr>
                                     <th>الفرع</th>
                                     <th>الحساب</th>
-                                    <th>الرصيد</th>
+                                    <th>الرصيد (عملة الحساب)</th>
+                                    <th>الرصيد (@Model.SelectedCurrencyCode)</th>
+                                    <th>الرصيد (@Model.BaseCurrencyCode)</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -185,6 +200,8 @@
                                         <td>@cb.BranchName</td>
                                         <td>@cb.AccountName</td>
                                         <td>@cb.Balance.ToString("N2")</td>
+                                        <td>@cb.BalanceSelected.ToString("N2")</td>
+                                        <td>@cb.BalanceBase.ToString("N2")</td>
                                     </tr>
                                 }
                             </tbody>
@@ -218,6 +235,7 @@
                     @if (Model.AccountTypeTrees.Any())
                     {
                         <div class="tree-container">
+                            @{ ViewData["SelectedCurrencyCode"] = Model.SelectedCurrencyCode; ViewData["BaseCurrencyCode"] = Model.BaseCurrencyCode; }
                             @await Html.PartialAsync("_AccountBalanceTreeNode", Model.AccountTypeTrees)
                         </div>
                     }
@@ -355,6 +373,7 @@
             const branchId = document.getElementById('branchFilter').value;
             const fromDate = document.getElementById('fromDateFilter').value;
             const toDate = document.getElementById('toDateFilter').value;
+            const currencyId = document.getElementById('currencyFilter').value;
             const url = new URL(window.location);
             if (branchId) {
                 url.searchParams.set('branchId', branchId);
@@ -370,6 +389,11 @@
                 url.searchParams.set('toDate', toDate);
             } else {
                 url.searchParams.delete('toDate');
+            }
+            if (currencyId) {
+                url.searchParams.set('currencyId', currencyId);
+            } else {
+                url.searchParams.delete('currencyId');
             }
             window.location.href = url.toString();
         }

--- a/AccountingSystem/Views/Shared/_AccountBalanceTreeNode.cshtml
+++ b/AccountingSystem/Views/Shared/_AccountBalanceTreeNode.cshtml
@@ -25,7 +25,13 @@
                     <span class="account-code">@node.Code</span>
                     <span class="account-name">@node.NameAr</span>
                 }
-                <span class="ms-auto">@node.Balance.ToString("N2")</span>
+                @{ var selectedCurrencyCode = ViewData["SelectedCurrencyCode"] as string ?? string.Empty;
+                   var baseCurrencyCode = ViewData["BaseCurrencyCode"] as string ?? string.Empty; }
+                <span class="ms-auto text-nowrap">
+                    <span title="رصيد عملة الحساب">@node.Balance.ToString("N2")</span>
+                    <span title="الرصيد بالعملة المختارة" class="text-primary">@node.BalanceSelected.ToString("N2") @selectedCurrencyCode</span>
+                    <span title="الرصيد بالعملة الأساسية" class="text-muted">@node.BalanceBase.ToString("N2") @baseCurrencyCode</span>
+                </span>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- add currency conversion service and register it
- allow dashboard to filter and display balances in selected and base currencies
- show cash box and account tree balances in account, selected, and base currencies

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68bdebe82068833395b2f38ee08b02cf