### PR TITLE
feat: add user payment accounts per currency

### DIFF
--- a/AccountingSystem/Data/ApplicationDbContext.cs
+++ b/AccountingSystem/Data/ApplicationDbContext.cs
@@ -38,6 +38,7 @@ namespace AccountingSystem.Data
         public DbSet<DisbursementVoucher> DisbursementVouchers { get; set; }
         public DbSet<Supplier> Suppliers { get; set; }
         public DbSet<SystemSetting> SystemSettings { get; set; }
+        public DbSet<UserPaymentAccount> UserPaymentAccounts { get; set; }
 
         public override int SaveChanges()
         {
@@ -387,6 +388,26 @@ namespace AccountingSystem.Data
                 entity.HasOne(u => u.PaymentBranch)
                     .WithMany()
                     .HasForeignKey(u => u.PaymentBranchId)
+                    .OnDelete(DeleteBehavior.Restrict);
+            });
+
+            builder.Entity<UserPaymentAccount>(entity =>
+            {
+                entity.HasKey(e => new { e.UserId, e.CurrencyId });
+
+                entity.HasOne(e => e.User)
+                    .WithMany(u => u.UserPaymentAccounts)
+                    .HasForeignKey(e => e.UserId)
+                    .OnDelete(DeleteBehavior.Cascade);
+
+                entity.HasOne(e => e.Currency)
+                    .WithMany()
+                    .HasForeignKey(e => e.CurrencyId)
+                    .OnDelete(DeleteBehavior.Cascade);
+
+                entity.HasOne(e => e.Account)
+                    .WithMany()
+                    .HasForeignKey(e => e.AccountId)
                     .OnDelete(DeleteBehavior.Restrict);
             });
 

--- a/AccountingSystem/Migrations/20250910172210_AddUserPaymentAccounts.Designer.cs
+++ b/AccountingSystem/Migrations/20250910172210_AddUserPaymentAccounts.Designer.cs
@@ -4,6 +4,7 @@ using AccountingSystem.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AccountingSystem.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250910172210_AddUserPaymentAccounts")]
+    partial class AddUserPaymentAccounts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/AccountingSystem/Migrations/20250910172210_AddUserPaymentAccounts.cs
+++ b/AccountingSystem/Migrations/20250910172210_AddUserPaymentAccounts.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AccountingSystem.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserPaymentAccounts : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UserPaymentAccounts",
+                columns: table => new
+                {
+                    UserId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    CurrencyId = table.Column<int>(type: "int", nullable: false),
+                    AccountId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserPaymentAccounts", x => new { x.UserId, x.CurrencyId });
+                    table.ForeignKey(
+                        name: "FK_UserPaymentAccounts_Accounts_AccountId",
+                        column: x => x.AccountId,
+                        principalTable: "Accounts",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_UserPaymentAccounts_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_UserPaymentAccounts_Currencies_CurrencyId",
+                        column: x => x.CurrencyId,
+                        principalTable: "Currencies",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserPaymentAccounts_AccountId",
+                table: "UserPaymentAccounts",
+                column: "AccountId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserPaymentAccounts_CurrencyId",
+                table: "UserPaymentAccounts",
+                column: "CurrencyId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserPaymentAccounts");
+        }
+    }
+}

--- a/AccountingSystem/Models/User.cs
+++ b/AccountingSystem/Models/User.cs
@@ -30,6 +30,7 @@ namespace AccountingSystem.Models
         public virtual ICollection<UserBranch> UserBranches { get; set; } = new List<UserBranch>();
         public virtual ICollection<UserPermission> UserPermissions { get; set; } = new List<UserPermission>();
         public virtual ICollection<JournalEntry> CreatedJournalEntries { get; set; } = new List<JournalEntry>();
+        public virtual ICollection<UserPaymentAccount> UserPaymentAccounts { get; set; } = new List<UserPaymentAccount>();
         public virtual Account? PaymentAccount { get; set; }
         public virtual Branch? PaymentBranch { get; set; }
         public virtual ICollection<Expense> Expenses { get; set; } = new List<Expense>();

--- a/AccountingSystem/Models/UserPaymentAccount.cs
+++ b/AccountingSystem/Models/UserPaymentAccount.cs
@@ -1,0 +1,18 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace AccountingSystem.Models
+{
+    public class UserPaymentAccount
+    {
+        [Required]
+        public string UserId { get; set; } = string.Empty;
+        public int CurrencyId { get; set; }
+        public int AccountId { get; set; }
+
+        // Navigation properties
+        public virtual User User { get; set; } = null!;
+        public virtual Currency Currency { get; set; } = null!;
+        public virtual Account Account { get; set; } = null!;
+    }
+}

--- a/AccountingSystem/ViewModels/UserViewModels.cs
+++ b/AccountingSystem/ViewModels/UserViewModels.cs
@@ -49,12 +49,11 @@ namespace AccountingSystem.ViewModels
         public bool IsActive { get; set; } = true;
         [MinLength(1, ErrorMessage = "يجب اختيار فرع واحد على الأقل")]
         public List<int> BranchIds { get; set; } = new List<int>();
-        public int? PaymentAccountId { get; set; }
         public int? PaymentBranchId { get; set; }
         public decimal ExpenseLimit { get; set; }
         public List<SelectListItem> Branches { get; set; } = new List<SelectListItem>();
         public List<SelectListItem> PaymentBranches { get; set; } = new List<SelectListItem>();
-        public List<SelectListItem> PaymentAccounts { get; set; } = new List<SelectListItem>();
+        public List<UserCurrencyAccountViewModel> CurrencyAccounts { get; set; } = new List<UserCurrencyAccountViewModel>();
     }
 
     public class EditUserViewModel
@@ -77,12 +76,11 @@ namespace AccountingSystem.ViewModels
         public bool IsActive { get; set; } = true;
         [MinLength(1, ErrorMessage = "يجب اختيار فرع واحد على الأقل")]
         public List<int> BranchIds { get; set; } = new List<int>();
-        public int? PaymentAccountId { get; set; }
         public int? PaymentBranchId { get; set; }
         public decimal ExpenseLimit { get; set; }
         public List<SelectListItem> Branches { get; set; } = new List<SelectListItem>();
         public List<SelectListItem> PaymentBranches { get; set; } = new List<SelectListItem>();
-        public List<SelectListItem> PaymentAccounts { get; set; } = new List<SelectListItem>();
+        public List<UserCurrencyAccountViewModel> CurrencyAccounts { get; set; } = new List<UserCurrencyAccountViewModel>();
     }
 
     public class ResetUserPasswordViewModel
@@ -120,5 +118,13 @@ namespace AccountingSystem.ViewModels
         [DataType(DataType.Password)]
         [Compare("NewPassword", ErrorMessage = "كلمتا المرور غير متطابقتين")] 
         public string ConfirmPassword { get; set; } = string.Empty;
+    }
+
+    public class UserCurrencyAccountViewModel
+    {
+        public int CurrencyId { get; set; }
+        public string CurrencyName { get; set; } = string.Empty;
+        public int? AccountId { get; set; }
+        public List<SelectListItem> Accounts { get; set; } = new List<SelectListItem>();
     }
 }

--- a/AccountingSystem/Views/Users/Create.cshtml
+++ b/AccountingSystem/Views/Users/Create.cshtml
@@ -39,13 +39,16 @@
             </select>
             <span asp-validation-for="PaymentBranchId" class="text-danger"></span>
         </div>
-        <div class="mb-3">
-            <label asp-for="PaymentAccountId" class="form-label"></label>
-            <select asp-for="PaymentAccountId" asp-items="Model.PaymentAccounts" class="form-select">
-                <option value="">-- اختر حساب الدفع --</option>
-            </select>
-            <span asp-validation-for="PaymentAccountId" class="text-danger"></span>
-        </div>
+        @for (int i = 0; i < Model.CurrencyAccounts.Count; i++)
+        {
+            <div class="mb-3">
+                <label class="form-label">حساب الدفع - @Model.CurrencyAccounts[i].CurrencyName</label>
+                <select asp-for="CurrencyAccounts[i].AccountId" asp-items="Model.CurrencyAccounts[i].Accounts" class="form-select">
+                    <option value="">-- اختر حساب الدفع --</option>
+                </select>
+                <span asp-validation-for="CurrencyAccounts[i].AccountId" class="text-danger"></span>
+            </div>
+        }
         <div class="mb-3">
             <label asp-for="ExpenseLimit" class="form-label"></label>
             <input asp-for="ExpenseLimit" class="form-control" />

--- a/AccountingSystem/Views/Users/Edit.cshtml
+++ b/AccountingSystem/Views/Users/Edit.cshtml
@@ -35,13 +35,16 @@
             </select>
             <span asp-validation-for="PaymentBranchId" class="text-danger"></span>
         </div>
-        <div class="mb-3">
-            <label asp-for="PaymentAccountId" class="form-label"></label>
-            <select asp-for="PaymentAccountId" asp-items="Model.PaymentAccounts" class="form-select">
-                <option value="">-- اختر حساب الدفع --</option>
-            </select>
-            <span asp-validation-for="PaymentAccountId" class="text-danger"></span>
-        </div>
+        @for (int i = 0; i < Model.CurrencyAccounts.Count; i++)
+        {
+            <div class="mb-3">
+                <label class="form-label">حساب الدفع - @Model.CurrencyAccounts[i].CurrencyName</label>
+                <select asp-for="CurrencyAccounts[i].AccountId" asp-items="Model.CurrencyAccounts[i].Accounts" class="form-select">
+                    <option value="">-- اختر حساب الدفع --</option>
+                </select>
+                <span asp-validation-for="CurrencyAccounts[i].AccountId" class="text-danger"></span>
+            </div>
+        }
         <div class="mb-3">
             <label asp-for="ExpenseLimit" class="form-label"></label>
             <input asp-for="ExpenseLimit" class="form-control" />


### PR DESCRIPTION
## Summary
- add `UserPaymentAccount` entity and context mapping
- allow creating/editing users with payment accounts per currency
- update user forms and view models for multi-currency support

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68c1b1f64c948333a0fb0be576dfcebf