### PR TITLE
Add payment vouchers with supplier support

### DIFF
--- a/AccountingSystem/Controllers/PaymentVouchersController.cs
+++ b/AccountingSystem/Controllers/PaymentVouchersController.cs
@@ -1,0 +1,146 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Identity;
+using AccountingSystem.Data;
+using AccountingSystem.Models;
+using AccountingSystem.Services;
+using System.Collections.Generic;
+
+namespace AccountingSystem.Controllers
+{
+    [Authorize(Policy = "paymentvouchers.view")]
+    public class PaymentVouchersController : Controller
+    {
+        private readonly ApplicationDbContext _context;
+        private readonly UserManager<User> _userManager;
+        private readonly IJournalEntryService _journalEntryService;
+
+        public PaymentVouchersController(ApplicationDbContext context, UserManager<User> userManager, IJournalEntryService journalEntryService)
+        {
+            _context = context;
+            _userManager = userManager;
+            _journalEntryService = journalEntryService;
+        }
+
+        public async Task<IActionResult> Index()
+        {
+            var user = await _userManager.GetUserAsync(User);
+            var vouchers = await _context.PaymentVouchers
+                .Where(v => v.CreatedById == user!.Id)
+                .Include(v => v.Supplier).ThenInclude(s => s.Account)
+                .Include(v => v.Currency)
+                .OrderByDescending(v => v.Date)
+                .ToListAsync();
+            return View(vouchers);
+        }
+
+        [Authorize(Policy = "paymentvouchers.create")]
+        public async Task<IActionResult> Create()
+        {
+            var user = await _userManager.GetUserAsync(User);
+            ViewBag.Suppliers = await _context.Suppliers
+                .Include(s => s.Account).ThenInclude(a => a.Currency)
+                .Select(s => new { s.Id, s.NameAr, s.AccountId, CurrencyId = s.Account!.CurrencyId, CurrencyCode = s.Account.Currency.Code })
+                .ToListAsync();
+
+            var setting = await _context.SystemSettings.FirstOrDefaultAsync(s => s.Key == "SupplierPaymentsParentAccountId");
+            if (setting != null && int.TryParse(setting.Value, out var parentAccountId))
+            {
+                ViewBag.Accounts = await _context.Accounts
+                    .Where(a => a.ParentId == parentAccountId)
+                    .Include(a => a.Currency)
+                    .Select(a => new { a.Id, a.Code, a.NameAr, a.CurrencyId, CurrencyCode = a.Currency.Code })
+                    .ToListAsync();
+            }
+            else
+            {
+                ViewBag.Accounts = new List<object>();
+            }
+
+            return View(new PaymentVoucher { Date = DateTime.Now, IsCash = true });
+        }
+
+        [HttpPost]
+        [Authorize(Policy = "paymentvouchers.create")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Create(PaymentVoucher model)
+        {
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null || user.PaymentAccountId == null || user.PaymentBranchId == null)
+                return Challenge();
+
+            var supplier = await _context.Suppliers
+                .Include(s => s.Account)
+                .FirstOrDefaultAsync(s => s.Id == model.SupplierId);
+            if (supplier?.Account == null)
+                ModelState.AddModelError("SupplierId", "المورد غير موجود");
+
+            Account? sourceAccount = null;
+            if (model.IsCash)
+            {
+                sourceAccount = await _context.Accounts.FindAsync(user.PaymentAccountId.Value);
+            }
+            else
+            {
+                sourceAccount = await _context.Accounts.FindAsync(model.AccountId);
+                var setting = await _context.SystemSettings.FirstOrDefaultAsync(s => s.Key == "SupplierPaymentsParentAccountId");
+                if (sourceAccount == null || setting == null || !int.TryParse(setting.Value, out var parentId) || sourceAccount.ParentId != parentId)
+                    ModelState.AddModelError("AccountId", "الحساب غير صالح");
+            }
+
+            if (supplier?.Account != null && sourceAccount != null && supplier.Account.CurrencyId != sourceAccount.CurrencyId)
+                ModelState.AddModelError("SupplierId", "يجب أن تكون الحسابات بنفس العملة");
+
+            if (!ModelState.IsValid)
+            {
+                ViewBag.Suppliers = await _context.Suppliers
+                    .Include(s => s.Account).ThenInclude(a => a.Currency)
+                    .Select(s => new { s.Id, s.NameAr, s.AccountId, CurrencyId = s.Account!.CurrencyId, CurrencyCode = s.Account.Currency.Code })
+                    .ToListAsync();
+
+                var setting = await _context.SystemSettings.FirstOrDefaultAsync(s => s.Key == "SupplierPaymentsParentAccountId");
+                if (setting != null && int.TryParse(setting.Value, out var parentAccountId))
+                {
+                    ViewBag.Accounts = await _context.Accounts
+                        .Where(a => a.ParentId == parentAccountId)
+                        .Include(a => a.Currency)
+                        .Select(a => new { a.Id, a.Code, a.NameAr, a.CurrencyId, CurrencyCode = a.Currency.Code })
+                        .ToListAsync();
+                }
+                else
+                {
+                    ViewBag.Accounts = new List<object>();
+                }
+
+                return View(model);
+            }
+
+            model.CurrencyId = supplier!.Account!.CurrencyId;
+            if (model.ExchangeRate <= 0)
+            {
+                var currency = await _context.Currencies.FindAsync(model.CurrencyId);
+                model.ExchangeRate = currency?.ExchangeRate ?? 1m;
+            }
+
+            model.CreatedById = user.Id;
+            _context.PaymentVouchers.Add(model);
+
+            var lines = new List<JournalEntryLine>
+            {
+                new JournalEntryLine { AccountId = supplier.AccountId!.Value, DebitAmount = model.Amount },
+                new JournalEntryLine { AccountId = model.IsCash ? user.PaymentAccountId.Value : model.AccountId!.Value, CreditAmount = model.Amount }
+            };
+
+            await _journalEntryService.CreateJournalEntryAsync(
+                model.Date,
+                model.Notes ?? "سند دفع",
+                user.PaymentBranchId.Value,
+                user.Id,
+                lines,
+                JournalEntryStatus.Posted);
+
+            return RedirectToAction(nameof(Index));
+        }
+    }
+}

--- a/AccountingSystem/Data/ApplicationDbContext.cs
+++ b/AccountingSystem/Data/ApplicationDbContext.cs
@@ -36,6 +36,7 @@ namespace AccountingSystem.Data
         public DbSet<Currency> Currencies { get; set; }
         public DbSet<ReceiptVoucher> ReceiptVouchers { get; set; }
         public DbSet<DisbursementVoucher> DisbursementVouchers { get; set; }
+        public DbSet<PaymentVoucher> PaymentVouchers { get; set; }
         public DbSet<Supplier> Suppliers { get; set; }
         public DbSet<SystemSetting> SystemSettings { get; set; }
         public DbSet<UserPaymentAccount> UserPaymentAccounts { get; set; }

--- a/AccountingSystem/Data/SeedData.cs
+++ b/AccountingSystem/Data/SeedData.cs
@@ -112,6 +112,8 @@ namespace AccountingSystem.Data
                 new Permission { Name = "receiptvouchers.create", DisplayName = "إنشاء سند قبض", Category = "السندات" },
                 new Permission { Name = "disbursementvouchers.view", DisplayName = " سندات الصرف", Category = "السندات" },
                 new Permission { Name = "disbursementvouchers.create", DisplayName = "إنشاء سند صرف", Category = "السندات" },
+                new Permission { Name = "paymentvouchers.view", DisplayName = "سندات الدفع", Category = "السندات" },
+                new Permission { Name = "paymentvouchers.create", DisplayName = "إنشاء سند دفع", Category = "السندات" },
                 new Permission { Name = "suppliers.view", DisplayName = "عرض الموردين", Category = "الموردين" },
                 new Permission { Name = "suppliers.create", DisplayName = "إنشاء الموردين", Category = "الموردين" },
                 new Permission { Name = "suppliers.edit", DisplayName = "تعديل الموردين", Category = "الموردين" },
@@ -286,8 +288,14 @@ namespace AccountingSystem.Data
             if (!context.SystemSettings.Any(s => s.Key == "SuppliersParentAccountId"))
             {
                 context.SystemSettings.Add(new SystemSetting { Key = "SuppliersParentAccountId", Value = null });
-                await context.SaveChangesAsync();
             }
+
+            if (!context.SystemSettings.Any(s => s.Key == "SupplierPaymentsParentAccountId"))
+            {
+                context.SystemSettings.Add(new SystemSetting { Key = "SupplierPaymentsParentAccountId", Value = null });
+            }
+
+            await context.SaveChangesAsync();
         }
 
         private static async Task SeedAdminPermissionsAsync(ApplicationDbContext context, User adminUser)

--- a/AccountingSystem/Migrations/20250910180750_AddPaymentVouchers.Designer.cs
+++ b/AccountingSystem/Migrations/20250910180750_AddPaymentVouchers.Designer.cs
@@ -4,6 +4,7 @@ using AccountingSystem.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AccountingSystem.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250910180750_AddPaymentVouchers")]
+    partial class AddPaymentVouchers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/AccountingSystem/Migrations/20250910180750_AddPaymentVouchers.cs
+++ b/AccountingSystem/Migrations/20250910180750_AddPaymentVouchers.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AccountingSystem.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPaymentVouchers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PaymentVouchers",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    SupplierId = table.Column<int>(type: "int", nullable: false),
+                    AccountId = table.Column<int>(type: "int", nullable: true),
+                    CurrencyId = table.Column<int>(type: "int", nullable: false),
+                    Amount = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    ExchangeRate = table.Column<decimal>(type: "decimal(18,6)", nullable: false),
+                    Date = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    Notes = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
+                    CreatedById = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    IsCash = table.Column<bool>(type: "bit", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PaymentVouchers", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PaymentVouchers_Accounts_AccountId",
+                        column: x => x.AccountId,
+                        principalTable: "Accounts",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_PaymentVouchers_AspNetUsers_CreatedById",
+                        column: x => x.CreatedById,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_PaymentVouchers_Currencies_CurrencyId",
+                        column: x => x.CurrencyId,
+                        principalTable: "Currencies",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_PaymentVouchers_Suppliers_SupplierId",
+                        column: x => x.SupplierId,
+                        principalTable: "Suppliers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PaymentVouchers_AccountId",
+                table: "PaymentVouchers",
+                column: "AccountId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PaymentVouchers_CreatedById",
+                table: "PaymentVouchers",
+                column: "CreatedById");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PaymentVouchers_CurrencyId",
+                table: "PaymentVouchers",
+                column: "CurrencyId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PaymentVouchers_SupplierId",
+                table: "PaymentVouchers",
+                column: "SupplierId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PaymentVouchers");
+        }
+    }
+}

--- a/AccountingSystem/Models/PaymentVoucher.cs
+++ b/AccountingSystem/Models/PaymentVoucher.cs
@@ -1,0 +1,41 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace AccountingSystem.Models
+{
+    public class PaymentVoucher
+    {
+        public int Id { get; set; }
+
+        [Required]
+        public int SupplierId { get; set; }
+
+        // Account used when voucher is non-cash (credit account)
+        public int? AccountId { get; set; }
+
+        [Required]
+        public int CurrencyId { get; set; }
+
+        [Column(TypeName = "decimal(18,2)")]
+        public decimal Amount { get; set; }
+
+        [Column(TypeName = "decimal(18,6)")]
+        public decimal ExchangeRate { get; set; } = 1m;
+
+        public DateTime Date { get; set; } = DateTime.Now;
+
+        [StringLength(500)]
+        public string? Notes { get; set; }
+
+        [Required]
+        public string CreatedById { get; set; } = string.Empty;
+
+        public bool IsCash { get; set; }
+
+        public virtual Supplier Supplier { get; set; } = null!;
+        public virtual Account? Account { get; set; }
+        public virtual Currency Currency { get; set; } = null!;
+        public virtual User CreatedBy { get; set; } = null!;
+    }
+}
+

--- a/AccountingSystem/Views/PaymentVouchers/Create.cshtml
+++ b/AccountingSystem/Views/PaymentVouchers/Create.cshtml
@@ -1,0 +1,99 @@
+@model AccountingSystem.Models.PaymentVoucher
+@{
+    ViewData["Title"] = "سند دفع جديد";
+    Layout = "~/Views/Shared/_AccountingLayout.cshtml";
+}
+
+<div class="container-fluid">
+    <form asp-action="Create" method="post" class="row g-3">
+        <div class="col-md-6">
+            <label class="form-label">المورد</label>
+            <select asp-for="SupplierId" class="form-select" id="supplierSelect">
+                @foreach (var s in ViewBag.Suppliers)
+                {
+                    <option value="@s.Id" data-account-id="@s.AccountId" data-currency-id="@s.CurrencyId" data-currency-code="@s.CurrencyCode">@s.NameAr</option>
+                }
+            </select>
+        </div>
+        <div class="col-md-6">
+            <label class="form-label">نوع الدفع</label>
+            <select asp-for="IsCash" class="form-select" id="paymentType">
+                <option value="true">نقدي</option>
+                <option value="false">غير نقدي</option>
+            </select>
+        </div>
+        <div class="col-md-6" id="accountContainer" style="display:none;">
+            <label class="form-label">الحساب</label>
+            <select asp-for="AccountId" class="form-select" id="accountSelect">
+                @foreach (var a in ViewBag.Accounts)
+                {
+                    <option value="@a.Id" data-currency-id="@a.CurrencyId" data-currency-code="@a.CurrencyCode">@a.Code - @a.NameAr (@a.CurrencyCode)</option>
+                }
+            </select>
+        </div>
+        <div class="col-md-6">
+            <label class="form-label">العملة</label>
+            <input type="text" class="form-control" id="currencyDisplay" readonly />
+            <input type="hidden" asp-for="CurrencyId" id="currencyId" />
+        </div>
+        <div class="col-md-6">
+            <label class="form-label">سعر الصرف</label>
+            <input asp-for="ExchangeRate" class="form-control" />
+        </div>
+        <div class="col-md-6">
+            <label class="form-label">المبلغ</label>
+            <input asp-for="Amount" class="form-control" />
+        </div>
+        <div class="col-md-6">
+            <label class="form-label">التاريخ</label>
+            <input asp-for="Date" type="date" class="form-control" />
+        </div>
+        <div class="col-md-6">
+            <label class="form-label">ملاحظات</label>
+            <textarea asp-for="Notes" class="form-control"></textarea>
+        </div>
+        <div class="col-12">
+            <button type="submit" class="btn btn-primary">حفظ</button>
+        </div>
+    </form>
+</div>
+
+@section Scripts {
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const supplierSelect = document.getElementById('supplierSelect');
+            const paymentType = document.getElementById('paymentType');
+            const accountContainer = document.getElementById('accountContainer');
+            const accountSelect = document.getElementById('accountSelect');
+            const currencyDisplay = document.getElementById('currencyDisplay');
+            const currencyId = document.getElementById('currencyId');
+
+            function updateCurrency() {
+                const option = supplierSelect.options[supplierSelect.selectedIndex];
+                currencyDisplay.value = option.getAttribute('data-currency-code') || '';
+                currencyId.value = option.getAttribute('data-currency-id') || '';
+                filterAccounts();
+            }
+
+            function toggleAccount() {
+                accountContainer.style.display = paymentType.value === 'true' ? 'none' : 'block';
+            }
+
+            function filterAccounts() {
+                const currency = currencyId.value;
+                if (accountSelect) {
+                    Array.from(accountSelect.options).forEach(function (opt) {
+                        opt.hidden = opt.getAttribute('data-currency-id') !== currency;
+                    });
+                    const firstVisible = Array.from(accountSelect.options).find(function (opt) { return !opt.hidden; });
+                    if (firstVisible) accountSelect.value = firstVisible.value;
+                }
+            }
+
+            supplierSelect.addEventListener('change', updateCurrency);
+            paymentType.addEventListener('change', toggleAccount);
+            updateCurrency();
+            toggleAccount();
+        });
+    </script>
+}

--- a/AccountingSystem/Views/PaymentVouchers/Index.cshtml
+++ b/AccountingSystem/Views/PaymentVouchers/Index.cshtml
@@ -1,0 +1,32 @@
+@model IEnumerable<AccountingSystem.Models.PaymentVoucher>
+@{
+    ViewData["Title"] = "سندات الدفع";
+    Layout = "~/Views/Shared/_AccountingLayout.cshtml";
+}
+
+<div class="container-fluid">
+    <a asp-action="Create" class="btn btn-primary mb-3">سند دفع جديد</a>
+    <table class="table table-striped table-hover">
+        <thead class="table-dark">
+            <tr>
+                <th>التاريخ</th>
+                <th>المورد</th>
+                <th>العملة</th>
+                <th>سعر الصرف</th>
+                <th>المبلغ</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var v in Model)
+            {
+                <tr>
+                    <td>@v.Date.ToString("yyyy-MM-dd")</td>
+                    <td>@v.Supplier.NameAr</td>
+                    <td>@v.Currency.Code</td>
+                    <td>@v.ExchangeRate.ToString("N6")</td>
+                    <td>@v.Amount.ToString("N2")</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+</div>

--- a/AccountingSystem/Views/Shared/_AccountingLayout.cshtml
+++ b/AccountingSystem/Views/Shared/_AccountingLayout.cshtml
@@ -36,16 +36,18 @@
         var canSystemSettings = (await AuthorizationService.AuthorizeAsync(User, "systemsettings.view")).Succeeded;
         var canReceiptVouchers = (await AuthorizationService.AuthorizeAsync(User, "receiptvouchers.view")).Succeeded;
         var canDisbursementVouchers = (await AuthorizationService.AuthorizeAsync(User, "disbursementvouchers.view")).Succeeded;
+        var canPaymentVouchers = (await AuthorizationService.AuthorizeAsync(User, "paymentvouchers.view")).Succeeded;
         var canReceiptVouchersCreate = (await AuthorizationService.AuthorizeAsync(User, "receiptvouchers.create")).Succeeded;
         var canDisbursementVouchersCreate = (await AuthorizationService.AuthorizeAsync(User, "disbursementvouchers.create")).Succeeded;
-        var showVouchers = canReceiptVouchers || canDisbursementVouchers || canReceiptVouchersCreate || canDisbursementVouchersCreate;
+        var canPaymentVouchersCreate = (await AuthorizationService.AuthorizeAsync(User, "paymentvouchers.create")).Succeeded;
+        var showVouchers = canReceiptVouchers || canDisbursementVouchers || canPaymentVouchers || canReceiptVouchersCreate || canDisbursementVouchersCreate || canPaymentVouchersCreate;
         var showAccountManagement = canBusinessStatementBulk || canBusinessRetStatementBulk || canBusnissShipmentsReturn || canBusnissStatment || canDriverPayment || canDriverStatment || canPrintSlip || canReceivePayments || canReceiveRetPayments || canUserPayment;
 
         var currentController = ViewContext.RouteData.Values["controller"]?.ToString()?.ToLower();
         var currentAction = ViewContext.RouteData.Values["action"]?.ToString()?.ToLower();
         var accountsActive = currentController == "accounts";
         var operationsActive = currentController == "cashboxclosures" || currentController == "expenses" || currentController == "transfers";
-        var vouchersActive = currentController == "receiptvouchers" || currentController == "disbursementvouchers";
+        var vouchersActive = currentController == "receiptvouchers" || currentController == "disbursementvouchers" || currentController == "paymentvouchers";
         var accountMgmtActive = currentController == "accountmanagement";
         var journalActive = currentController == "journalentries";
         var reportsActive = currentController == "reports";
@@ -125,6 +127,14 @@
                             @if (canDisbursementVouchersCreate)
                             {
                                 <li class="nav-item"><a class="nav-link" href="@Url.Action("Create", "DisbursementVouchers")"><i class="fas fa-plus"></i> إضافة سند صرف</a></li>
+                            }
+                            @if (canPaymentVouchers)
+                            {
+                                <li class="nav-item"><a class="nav-link" href="@Url.Action("Index", "PaymentVouchers")"><i class="fas fa-list"></i> سندات الدفع</a></li>
+                            }
+                            @if (canPaymentVouchersCreate)
+                            {
+                                <li class="nav-item"><a class="nav-link" href="@Url.Action("Create", "PaymentVouchers")"><i class="fas fa-plus"></i> إضافة سند دفع</a></li>
                             }
                         </ul>
                     </li>


### PR DESCRIPTION
## Summary
- add PaymentVoucher model, controller and views with cash/non-cash logic
- seed permissions and system setting for payment vouchers
- expose payment vouchers in layout and EF context

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68c1bd3a5fe4833388863146dcce7b41