### PR TITLE
تطوير واجهة إنشاء الحوالة لإظهار حسابات المستخدم

### DIFF
--- a/AccountingSystem/Controllers/TransfersController.cs
+++ b/AccountingSystem/Controllers/TransfersController.cs
@@ -1,5 +1,6 @@
 using AccountingSystem.Data;
 using AccountingSystem.Models;
+using AccountingSystem.ViewModels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -7,6 +8,7 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Linq;
+using System.Collections.Generic;
 using System.Text.Json;
 
 namespace AccountingSystem.Controllers
@@ -39,58 +41,79 @@ namespace AccountingSystem.Controllers
         }
 
         [Authorize(Policy = "transfers.create")]
-        public IActionResult Create()
-        {
-            var userId = _userManager.GetUserId(User);
-            var users = _context.Users
-                .Where(u => u.Id != userId)
-                .Include(u => u.PaymentBranch)
-                .ToList();
-            ViewData["Users"] = new SelectList(users, "Id", "FullName");
-            ViewBag.UserBranches = JsonSerializer.Serialize(users.ToDictionary(u => u.Id, u => u.PaymentBranch?.NameAr ?? ""));
-            var senderBranch = _context.Users
-                .Where(u => u.Id == userId)
-                .Include(u => u.PaymentBranch)
-                .Select(u => u.PaymentBranch!.NameAr)
-                .FirstOrDefault();
-            ViewBag.SenderBranch = senderBranch;
-            return View();
-        }
-
-        [HttpPost]
-        [ValidateAntiForgeryToken]
-        [Authorize(Policy = "transfers.create")]
-        public async Task<IActionResult> Create(string receiverId, decimal amount, string? notes)
+        public async Task<IActionResult> Create()
         {
             var sender = await _userManager.GetUserAsync(User);
             if (sender == null)
                 return Challenge();
 
-            var receiver = await _context.Users.Include(u => u.PaymentBranch).FirstOrDefaultAsync(u => u.Id == receiverId);
+            var model = new TransferCreateViewModel();
+            await PopulateCreateViewModelAsync(model, sender.Id);
+            return View(model);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        [Authorize(Policy = "transfers.create")]
+        public async Task<IActionResult> Create(TransferCreateViewModel model)
+        {
+            var sender = await _userManager.GetUserAsync(User);
+            if (sender == null)
+                return Challenge();
+
+            if (!ModelState.IsValid)
+            {
+                await PopulateCreateViewModelAsync(model, sender.Id);
+                return View(model);
+            }
+
+            if (!model.FromPaymentAccountId.HasValue)
+            {
+                ModelState.AddModelError(nameof(model.FromPaymentAccountId), "الرجاء اختيار حساب الإرسال");
+                await PopulateCreateViewModelAsync(model, sender.Id);
+                return View(model);
+            }
+
+            var senderAccount = await _context.UserPaymentAccounts
+                .Include(u => u.Account)
+                .FirstOrDefaultAsync(u => u.UserId == sender.Id && u.AccountId == model.FromPaymentAccountId.Value);
+            if (senderAccount == null)
+            {
+                ModelState.AddModelError(nameof(model.FromPaymentAccountId), "الحساب المحدد غير متاح للمستخدم");
+                await PopulateCreateViewModelAsync(model, sender.Id);
+                return View(model);
+            }
+
+            var receiver = await _context.Users
+                .Include(u => u.PaymentBranch)
+                .FirstOrDefaultAsync(u => u.Id == model.ReceiverId);
             if (receiver == null || receiver.Id == sender.Id)
             {
-                ModelState.AddModelError("receiverId", receiver == null ? "المستلم غير موجود" : "لا يمكن إرسال حوالة لنفسك");
-                var users = _context.Users
-                    .Where(u => u.Id != sender.Id)
-                    .Include(u => u.PaymentBranch)
-                    .ToList();
-                ViewData["Users"] = new SelectList(users, "Id", "FullName");
-                ViewBag.UserBranches = JsonSerializer.Serialize(users.ToDictionary(u => u.Id, u => u.PaymentBranch?.NameAr ?? ""));
-                var senderBranch = await _context.Branches.FindAsync(sender.PaymentBranchId);
-                ViewBag.SenderBranch = senderBranch?.NameAr;
-                return View();
+                ModelState.AddModelError(nameof(model.ReceiverId), receiver == null ? "المستلم غير موجود" : "لا يمكن إرسال حوالة لنفسك");
+                await PopulateCreateViewModelAsync(model, sender.Id);
+                return View(model);
+            }
+
+            var receiverAccount = await _context.UserPaymentAccounts
+                .Include(u => u.Account)
+                .FirstOrDefaultAsync(u => u.UserId == receiver.Id && u.CurrencyId == senderAccount.CurrencyId);
+            if (receiverAccount == null)
+            {
+                ModelState.AddModelError(nameof(model.ReceiverId), "لا يوجد للمستلم حساب بنفس عملة الحساب المرسل");
+                await PopulateCreateViewModelAsync(model, sender.Id);
+                return View(model);
             }
 
             var transfer = new PaymentTransfer
             {
                 SenderId = sender.Id,
                 ReceiverId = receiver.Id,
-                FromPaymentAccountId = sender.PaymentAccountId ?? 0,
-                ToPaymentAccountId = receiver.PaymentAccountId ?? 0,
+                FromPaymentAccountId = model.FromPaymentAccountId.Value,
+                ToPaymentAccountId = receiverAccount.AccountId,
                 FromBranchId = sender.PaymentBranchId,
                 ToBranchId = receiver.PaymentBranchId,
-                Amount = amount,
-                Notes = notes,
+                Amount = model.Amount,
+                Notes = model.Notes,
                 Status = TransferStatus.Pending,
                 CreatedAt = DateTime.Now
             };
@@ -196,8 +219,38 @@ namespace AccountingSystem.Controllers
                 return View(transfer);
             }
 
+            var fromAccount = await _context.Accounts.FindAsync(transfer.FromPaymentAccountId);
+            if (fromAccount == null)
+            {
+                ModelState.AddModelError(string.Empty, "حساب الإرسال غير موجود");
+                var users = _context.Users
+                    .Where(u => u.Id != userId)
+                    .Include(u => u.PaymentBranch)
+                    .ToList();
+                ViewData["Users"] = new SelectList(users, "Id", "FullName", receiverId);
+                ViewBag.UserBranches = JsonSerializer.Serialize(users.ToDictionary(u => u.Id, u => u.PaymentBranch?.NameAr ?? ""));
+                ViewBag.SenderBranch = transfer.FromBranch?.NameAr;
+                return View(transfer);
+            }
+
+            var receiverAccount = await _context.UserPaymentAccounts
+                .Include(u => u.Account)
+                .FirstOrDefaultAsync(u => u.UserId == receiver.Id && u.CurrencyId == fromAccount.CurrencyId);
+            if (receiverAccount == null)
+            {
+                ModelState.AddModelError("receiverId", "لا يوجد للمستلم حساب بنفس عملة الحساب المرسل");
+                var users = _context.Users
+                    .Where(u => u.Id != userId)
+                    .Include(u => u.PaymentBranch)
+                    .ToList();
+                ViewData["Users"] = new SelectList(users, "Id", "FullName", receiverId);
+                ViewBag.UserBranches = JsonSerializer.Serialize(users.ToDictionary(u => u.Id, u => u.PaymentBranch?.NameAr ?? ""));
+                ViewBag.SenderBranch = transfer.FromBranch?.NameAr;
+                return View(transfer);
+            }
+
             transfer.ReceiverId = receiver.Id;
-            transfer.ToPaymentAccountId = receiver.PaymentAccountId ?? 0;
+            transfer.ToPaymentAccountId = receiverAccount.AccountId;
             transfer.ToBranchId = receiver.PaymentBranchId;
             transfer.Amount = amount;
             transfer.Notes = notes;
@@ -219,6 +272,77 @@ namespace AccountingSystem.Controllers
             _context.PaymentTransfers.Remove(transfer);
             await _context.SaveChangesAsync();
             return RedirectToAction(nameof(Index));
+        }
+
+        private async Task PopulateCreateViewModelAsync(TransferCreateViewModel model, string senderId)
+        {
+            var users = await _context.Users
+                .Where(u => u.Id != senderId)
+                .Include(u => u.PaymentBranch)
+                .ToListAsync();
+
+            var receiverItems = users
+                .Select(u => new SelectListItem
+                {
+                    Value = u.Id,
+                    Text = u.FullName ?? $"{u.FirstName} {u.LastName}",
+                    Selected = u.Id == model.ReceiverId
+                })
+                .ToList();
+
+            model.Receivers = receiverItems;
+            model.ReceiverBranches = users.ToDictionary(u => u.Id, u => u.PaymentBranch?.NameAr ?? string.Empty);
+
+            var senderAccounts = await _context.UserPaymentAccounts
+                .Where(up => up.UserId == senderId)
+                .Include(up => up.Account).ThenInclude(a => a.Currency)
+                .OrderBy(up => up.Account.NameAr)
+                .ToListAsync();
+
+            var accountOptions = senderAccounts
+                .Select(up => new TransferCreateViewModel.SenderAccountOption
+                {
+                    AccountId = up.AccountId,
+                    DisplayName = $"{up.Account.Code} - {up.Account.NameAr} ({up.Account.Currency.Code})",
+                    CurrencyId = up.Account.CurrencyId,
+                    CurrencyCode = up.Account.Currency.Code
+                })
+                .ToList();
+
+            model.SenderAccounts = accountOptions;
+
+            if (!model.FromPaymentAccountId.HasValue && accountOptions.Any())
+                model.FromPaymentAccountId = accountOptions.First().AccountId;
+
+            model.SenderBranch = await _context.Users
+                .Where(u => u.Id == senderId)
+                .Include(u => u.PaymentBranch)
+                .Select(u => u.PaymentBranch!.NameAr)
+                .FirstOrDefaultAsync() ?? string.Empty;
+
+            var receiverIds = users.Select(u => u.Id).ToList();
+            if (receiverIds.Count == 0)
+            {
+                model.ReceiverAccounts = new Dictionary<string, List<TransferCreateViewModel.ReceiverAccountOption>>();
+                return;
+            }
+
+            var receiverAccountList = await _context.UserPaymentAccounts
+                .Where(up => receiverIds.Contains(up.UserId))
+                .Include(up => up.Account).ThenInclude(a => a.Currency)
+                .ToListAsync();
+
+            model.ReceiverAccounts = receiverAccountList
+                .GroupBy(up => up.UserId)
+                .ToDictionary(
+                    g => g.Key,
+                    g => g.Select(up => new TransferCreateViewModel.ReceiverAccountOption
+                    {
+                        AccountId = up.AccountId,
+                        CurrencyId = up.CurrencyId,
+                        DisplayName = $"{up.Account.Code} - {up.Account.NameAr} ({up.Account.Currency.Code})"
+                    }).ToList()
+                );
         }
 
         private async Task UpdateAccountBalances(JournalEntry entry)

--- a/AccountingSystem/ViewModels/TransferViewModels.cs
+++ b/AccountingSystem/ViewModels/TransferViewModels.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace AccountingSystem.ViewModels
+{
+    public class TransferCreateViewModel
+    {
+        [Required(ErrorMessage = "الرجاء اختيار المستلم")]
+        public string? ReceiverId { get; set; }
+
+        [Display(Name = "حساب الإرسال")]
+        [Required(ErrorMessage = "الرجاء اختيار حساب الإرسال")]
+        public int? FromPaymentAccountId { get; set; }
+
+        [Display(Name = "المبلغ")]
+        [Required(ErrorMessage = "الرجاء إدخال مبلغ الحوالة")]
+        [Range(typeof(decimal), "0.01", "79228162514264337593543950335", ErrorMessage = "المبلغ يجب أن يكون أكبر من صفر")]
+        public decimal Amount { get; set; }
+
+        [Display(Name = "ملاحظات")]
+        public string? Notes { get; set; }
+
+        public string SenderBranch { get; set; } = string.Empty;
+
+        public IEnumerable<SelectListItem> Receivers { get; set; } = new List<SelectListItem>();
+
+        public IEnumerable<SenderAccountOption> SenderAccounts { get; set; } = new List<SenderAccountOption>();
+
+        public Dictionary<string, string> ReceiverBranches { get; set; } = new();
+
+        public Dictionary<string, List<ReceiverAccountOption>> ReceiverAccounts { get; set; } = new();
+
+        public class SenderAccountOption
+        {
+            public int AccountId { get; set; }
+            public string DisplayName { get; set; } = string.Empty;
+            public int CurrencyId { get; set; }
+            public string CurrencyCode { get; set; } = string.Empty;
+        }
+
+        public class ReceiverAccountOption
+        {
+            public int AccountId { get; set; }
+            public int CurrencyId { get; set; }
+            public string DisplayName { get; set; } = string.Empty;
+        }
+    }
+}

--- a/AccountingSystem/Views/Transfers/Create.cshtml
+++ b/AccountingSystem/Views/Transfers/Create.cshtml
@@ -1,42 +1,107 @@
+@model AccountingSystem.ViewModels.TransferCreateViewModel
+@using System.Text.Json
+
 @{
     ViewData["Title"] = "إنشاء حوالة";
+    var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+    var branchesJson = JsonSerializer.Serialize(Model.ReceiverBranches, jsonOptions);
+    var accountsJson = JsonSerializer.Serialize(Model.ReceiverAccounts, jsonOptions);
 }
 
 <h2>إنشاء حوالة</h2>
 
 <form asp-action="Create" method="post">
+    @Html.AntiForgeryToken()
+    <div asp-validation-summary="All" class="text-danger"></div>
+
     <div class="form-group">
-        <label>المستلم</label>
-        <select id="receiverSelect" name="receiverId" class="form-control" asp-items="ViewBag.Users"></select>
+        <label asp-for="FromPaymentAccountId"></label>
+        <select asp-for="FromPaymentAccountId" class="form-control" id="senderAccountSelect">
+            <option value="">اختر حساب الإرسال</option>
+            @foreach (var account in Model.SenderAccounts)
+            {
+                <option value="@account.AccountId"
+                        data-currency-id="@account.CurrencyId"
+                        data-currency-code="@account.CurrencyCode"
+                        @(Model.FromPaymentAccountId == account.AccountId ? "selected=\"selected\"" : "")>
+                    @account.DisplayName
+                </option>
+            }
+        </select>
+        <span asp-validation-for="FromPaymentAccountId" class="text-danger"></span>
     </div>
+
+    <div class="form-group">
+        <label asp-for="ReceiverId"></label>
+        <select asp-for="ReceiverId" class="form-control" id="receiverSelect">
+            <option value="">اختر المستلم</option>
+            @foreach (var receiver in Model.Receivers)
+            {
+                <option value="@receiver.Value" @(receiver.Selected ? "selected=\"selected\"" : "")>@receiver.Text</option>
+            }
+        </select>
+        <span asp-validation-for="ReceiverId" class="text-danger"></span>
+    </div>
+
     <div class="form-group">
         <label>فرع الإرسال</label>
-        <input type="text" class="form-control" value="@ViewBag.SenderBranch" disabled />
+        <input type="text" class="form-control" value="@Model.SenderBranch" disabled />
     </div>
     <div class="form-group">
         <label>فرع الاستقبال</label>
         <input type="text" id="receiverBranch" class="form-control" disabled />
     </div>
     <div class="form-group">
-        <label>المبلغ</label>
-        <input type="number" step="0.01" name="amount" class="form-control" />
+        <label>حساب المستلم</label>
+        <input type="text" id="receiverAccountDisplay" class="form-control" disabled />
     </div>
+
     <div class="form-group">
-        <label>ملاحظات</label>
-        <textarea name="notes" class="form-control"></textarea>
+        <label asp-for="Amount"></label>
+        <input asp-for="Amount" class="form-control" />
+        <span asp-validation-for="Amount" class="text-danger"></span>
     </div>
+
+    <div class="form-group">
+        <label asp-for="Notes"></label>
+        <textarea asp-for="Notes" class="form-control"></textarea>
+        <span asp-validation-for="Notes" class="text-danger"></span>
+    </div>
+
     <button type="submit" class="btn btn-primary">إرسال</button>
 </form>
 
 @section Scripts {
+    <partial name="_ValidationScriptsPartial" />
     <script>
-        const branches = @Html.Raw(ViewBag.UserBranches ?? "{}");
-        const select = document.getElementById('receiverSelect');
+        const branches = @Html.Raw(branchesJson);
+        const receiverAccounts = @Html.Raw(accountsJson);
         const branchInput = document.getElementById('receiverBranch');
-        function updateBranch() {
-            branchInput.value = branches[select.value] || '';
+        const accountDisplay = document.getElementById('receiverAccountDisplay');
+        const receiverSelect = document.getElementById('receiverSelect');
+        const senderAccountSelect = document.getElementById('senderAccountSelect');
+
+        function updateReceiverInfo() {
+            const receiverId = receiverSelect.value;
+            branchInput.value = branches[receiverId] || '';
+
+            const selectedOption = senderAccountSelect.options[senderAccountSelect.selectedIndex];
+            const currencyIdValue = selectedOption ? Number(selectedOption.dataset.currencyId) : null;
+            const hasCurrency = Number.isFinite(currencyIdValue);
+            const accounts = receiverAccounts[receiverId] || [];
+            const matchingAccount = hasCurrency ? accounts.find(a => a.currencyId === currencyIdValue) : null;
+
+            if (matchingAccount) {
+                accountDisplay.value = matchingAccount.displayName;
+            } else if (receiverId && hasCurrency) {
+                accountDisplay.value = 'لا يوجد حساب متاح بنفس العملة';
+            } else {
+                accountDisplay.value = '';
+            }
         }
-        select.addEventListener('change', updateBranch);
-        updateBranch();
+
+        receiverSelect.addEventListener('change', updateReceiverInfo);
+        senderAccountSelect.addEventListener('change', updateReceiverInfo);
+        updateReceiverInfo();
     </script>
 }


### PR DESCRIPTION
## Summary
- إضافة نموذج عرض جديد لإنشاء الحوالة مع بيانات الحسابات والفروع
- تحديث TransfersController لاستخدام النموذج وضمان مطابقة عملة المستلم
- تحسين واجهة الإنشاء لعرض حسابات المستخدم وإظهار حساب المستلم الموافق للعملة

## Testing
- dotnet build *(fails: الأمر dotnet غير متوفر في بيئة التشغيل)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a1d71bb083338cd0868cafe5c3f5