### PR TITLE
Fix analyzer warnings for nullable context and async handlers

### DIFF
--- a/AccountingSystem/AccountingSystem.csproj
+++ b/AccountingSystem/AccountingSystem.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
-    <Nullable>disable</Nullable>
+    <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/AccountingSystem/Controllers/AccountManagementController.cs
+++ b/AccountingSystem/Controllers/AccountManagementController.cs
@@ -95,7 +95,6 @@ namespace Roadfn.Controllers
                         Name = c.SenderName
                     };
             var Data = await t.ToListAsync();
-            var count = Data.Count();
             if (dm.where != null)
             {
                 Data = (from cust in Data
@@ -116,7 +115,6 @@ namespace Roadfn.Controllers
                         Name = c.IUser
                     };
             var Data = await t.ToListAsync();
-            var count = Data.Count();
             if (dm.where != null)
             {
                 Data = (from cust in Data
@@ -137,7 +135,6 @@ namespace Roadfn.Controllers
                         Name = c.SenderName
                     };
             var Data = await t.ToListAsync();
-            var count = Data.Count();
             if (dm.where != null)
             {
                 Data = (from cust in Data
@@ -157,8 +154,7 @@ namespace Roadfn.Controllers
                         Id = c.DriverID,
                         Name = c.DriverName
                     };
-            var Data = t.ToList();
-            var count = Data.Count();
+            var Data = await t.ToListAsync();
             if (dm.where != null)
             {
                 Data = (from cust in Data
@@ -967,7 +963,7 @@ namespace Roadfn.Controllers
             }
             return dm.RequiresCounts ? Json(new { result = DataSource, count = count }) : Json(DataSource);
         }
-        public async Task<IActionResult> UrlDatasourceRPTPaymentHistoryDriver([FromBody] DataManagerRequest dm, int? DriverID, DateTime? fromDate, DateTime? toDate)
+        public IActionResult UrlDatasourceRPTPaymentHistoryDriver([FromBody] DataManagerRequest dm, int? DriverID, DateTime? fromDate, DateTime? toDate)
         {
             if (fromDate == null && toDate == null)
             {
@@ -1000,7 +996,7 @@ namespace Roadfn.Controllers
             }
             return dm.RequiresCounts ? Json(new { result = DataSource, count = count }) : Json(DataSource);
         }
-        public async Task<IActionResult> UrlDatasourceRPTPaymentHistoryUser([FromBody] DataManagerRequest dm, int? userID, DateTime? fromDate, DateTime? toDate)
+        public IActionResult UrlDatasourceRPTPaymentHistoryUser([FromBody] DataManagerRequest dm, int? userID, DateTime? fromDate, DateTime? toDate)
         {
             if (fromDate == null && toDate == null)
             {

--- a/AccountingSystem/Data/RoadFnDbContext.cs
+++ b/AccountingSystem/Data/RoadFnDbContext.cs
@@ -1,6 +1,7 @@
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Metadata;
 using DocumentFormat.OpenXml.Bibliography;
 using DocumentFormat.OpenXml.ExtendedProperties;
 using Roadfn.Models;
@@ -72,14 +73,21 @@ namespace AccountingSystem.Data
                                     entitiesChanges.OldValue = oldValue?.ToString();
                                     entitiesChanges.EntityId = Id;
                                     entitiesChanges.IUser = _user;
-                                    entitiesChanges.TableName = propName.DeclaringEntityType.Name;
+                                    if (propName.DeclaringType is IEntityType entityType)
+                                    {
+                                        entitiesChanges.TableName = entityType.Name;
+                                    }
+                                    else
+                                    {
+                                        entitiesChanges.TableName = propName.DeclaringType?.Name ?? string.Empty;
+                                    }
                                     this.EntitiesChanges.Add(entitiesChanges);
                                 }
                             }
                         }
                         catch (Exception ex)
                         {
-
+                            Console.WriteLine($"Error tracking entity changes: {ex}");
                         }
 
                     }

--- a/AccountingSystem/Migrations/20250902181645_dbini.Designer.cs
+++ b/AccountingSystem/Migrations/20250902181645_dbini.Designer.cs
@@ -13,7 +13,7 @@ namespace AccountingSystem.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
     [Migration("20250902181645_dbini")]
-    partial class dbini
+    partial class DbIni
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)

--- a/AccountingSystem/Migrations/20250902181645_dbini.cs
+++ b/AccountingSystem/Migrations/20250902181645_dbini.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace AccountingSystem.Migrations
 {
     /// <inheritdoc />
-    public partial class dbini : Migration
+    public partial class DbIni : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/AccountingSystem/Migrations/20250908171446_updatedb.Designer.cs
+++ b/AccountingSystem/Migrations/20250908171446_updatedb.Designer.cs
@@ -13,7 +13,7 @@ namespace AccountingSystem.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
     [Migration("20250908171446_updatedb")]
-    partial class updatedb
+    partial class UpdateDb
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)

--- a/AccountingSystem/Migrations/20250908171446_updatedb.cs
+++ b/AccountingSystem/Migrations/20250908171446_updatedb.cs
@@ -5,7 +5,7 @@
 namespace AccountingSystem.Migrations
 {
     /// <inheritdoc />
-    public partial class updatedb : Migration
+    public partial class UpdateDb : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/AccountingSystem/Migrations/20250908195309_updatedb124.Designer.cs
+++ b/AccountingSystem/Migrations/20250908195309_updatedb124.Designer.cs
@@ -13,7 +13,7 @@ namespace AccountingSystem.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
     [Migration("20250908195309_updatedb124")]
-    partial class updatedb124
+    partial class UpdateDb124
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)

--- a/AccountingSystem/Migrations/20250908195309_updatedb124.cs
+++ b/AccountingSystem/Migrations/20250908195309_updatedb124.cs
@@ -5,7 +5,7 @@
 namespace AccountingSystem.Migrations
 {
     /// <inheritdoc />
-    public partial class updatedb124 : Migration
+    public partial class UpdateDb124 : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/AccountingSystem/Migrations/20250908201924_updatedb1247.Designer.cs
+++ b/AccountingSystem/Migrations/20250908201924_updatedb1247.Designer.cs
@@ -13,7 +13,7 @@ namespace AccountingSystem.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
     [Migration("20250908201924_updatedb1247")]
-    partial class updatedb1247
+    partial class UpdateDb1247
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)

--- a/AccountingSystem/Migrations/20250908201924_updatedb1247.cs
+++ b/AccountingSystem/Migrations/20250908201924_updatedb1247.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace AccountingSystem.Migrations
 {
     /// <inheritdoc />
-    public partial class updatedb1247 : Migration
+    public partial class UpdateDb1247 : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/AccountingSystem/Migrations/20250910181542_payvvsee.Designer.cs
+++ b/AccountingSystem/Migrations/20250910181542_payvvsee.Designer.cs
@@ -13,7 +13,7 @@ namespace AccountingSystem.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
     [Migration("20250910181542_payvvsee")]
-    partial class payvvsee
+    partial class Payvvsee
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)

--- a/AccountingSystem/Migrations/20250910181542_payvvsee.cs
+++ b/AccountingSystem/Migrations/20250910181542_payvvsee.cs
@@ -5,7 +5,7 @@
 namespace AccountingSystem.Migrations
 {
     /// <inheritdoc />
-    public partial class payvvsee : Migration
+    public partial class Payvvsee : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/AccountingSystem/Migrations/20250910181627_payvvsee1.Designer.cs
+++ b/AccountingSystem/Migrations/20250910181627_payvvsee1.Designer.cs
@@ -13,7 +13,7 @@ namespace AccountingSystem.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
     [Migration("20250910181627_payvvsee1")]
-    partial class payvvsee1
+    partial class Payvvsee1
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)

--- a/AccountingSystem/Migrations/20250910181627_payvvsee1.cs
+++ b/AccountingSystem/Migrations/20250910181627_payvvsee1.cs
@@ -5,7 +5,7 @@
 namespace AccountingSystem.Migrations
 {
     /// <inheritdoc />
-    public partial class payvvsee1 : Migration
+    public partial class Payvvsee1 : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/AccountingSystem/Migrations/20250910195708_tblmappingacocounts.Designer.cs
+++ b/AccountingSystem/Migrations/20250910195708_tblmappingacocounts.Designer.cs
@@ -13,7 +13,7 @@ namespace AccountingSystem.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
     [Migration("20250910195708_tblmappingacocounts")]
-    partial class tblmappingacocounts
+    partial class TblMappingAcocounts
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)

--- a/AccountingSystem/Migrations/20250910195708_tblmappingacocounts.cs
+++ b/AccountingSystem/Migrations/20250910195708_tblmappingacocounts.cs
@@ -5,7 +5,7 @@
 namespace AccountingSystem.Migrations
 {
     /// <inheritdoc />
-    public partial class tblmappingacocounts : Migration
+    public partial class TblMappingAcocounts : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/AccountingSystem/Views/AccountManagement/BusinessRetStatementBulk.cshtml
+++ b/AccountingSystem/Views/AccountManagement/BusinessRetStatementBulk.cshtml
@@ -1,6 +1,5 @@
-﻿@{
+@{
     var rtl = true;
-    var delete = true;
     ViewData["Title"] = "اصدار كلي لفاتورة طرود مرتجعه";
 }
 

--- a/AccountingSystem/Views/AccountManagement/BusinessStatementBulk.cshtml
+++ b/AccountingSystem/Views/AccountManagement/BusinessStatementBulk.cshtml
@@ -1,6 +1,5 @@
-﻿@{
+@{
     var rtl = true;
-    var delete = true;
     ViewData["Title"] = "حساب العميل كلي";
 }
 

--- a/AccountingSystem/Views/Transfers/Create.cshtml
+++ b/AccountingSystem/Views/Transfers/Create.cshtml
@@ -23,7 +23,7 @@
                 <option value="@account.AccountId"
                         data-currency-id="@account.CurrencyId"
                         data-currency-code="@account.CurrencyCode"
-                        @(Model.FromPaymentAccountId == account.AccountId ? "selected=\"selected\"" : "")>
+                        selected="@(Model.FromPaymentAccountId == account.AccountId)">
                     @account.DisplayName
                 </option>
             }
@@ -37,7 +37,7 @@
             <option value="">اختر المستلم</option>
             @foreach (var receiver in Model.Receivers)
             {
-                <option value="@receiver.Value" @(receiver.Selected ? "selected=\"selected\"" : "")>@receiver.Text</option>
+                <option value="@receiver.Value" selected="@receiver.Selected">@receiver.Text</option>
             }
         </select>
         <span asp-validation-for="ReceiverId" class="text-danger"></span>


### PR DESCRIPTION
## Summary
- enable nullable reference types for the web project so annotated code compiles cleanly
- ensure account management handlers await EF Core queries and make sync data endpoints non-async
- update change-tracking metadata usage, rename legacy migrations to PascalCase, and clean Razor views to avoid tag-helper warnings

## Testing
- Not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68c9b1ada1f88333b61c371750dcae8d