### PR TITLE
Fix users index view compilation issues

### DIFF
--- a/AccountingSystem/ViewModels/UserViewModels.cs
+++ b/AccountingSystem/ViewModels/UserViewModels.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc.Rendering;

--- a/AccountingSystem/Views/Users/Index.cshtml
+++ b/AccountingSystem/Views/Users/Index.cshtml
@@ -43,7 +43,14 @@
                             }
                             @foreach (var size in pageSizes)
                             {
-                                <option value="@size" @(size == Model.PageSize ? "selected" : null)>@size</option>
+                                if (size == Model.PageSize)
+                                {
+                                    <option value="@size" selected="selected">@size</option>
+                                }
+                                else
+                                {
+                                    <option value="@size">@size</option>
+                                }
                             }
                         </select>
                     </div>


### PR DESCRIPTION
## Summary
- add the missing System namespace to the user view models so DateTime members compile
- adjust the users index page-size dropdown to select the current value without inline C# attributes

## Testing
- `dotnet build` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d057f084a88333a21d0901bf5fc2b2