### PR TITLE
Add driver and business branch selections to users

### DIFF
--- a/AccountingSystem/Migrations/20250921202747_AddUserAccountBranchSelections.Designer.cs
+++ b/AccountingSystem/Migrations/20250921202747_AddUserAccountBranchSelections.Designer.cs
@@ -4,6 +4,7 @@ using AccountingSystem.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AccountingSystem.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250921202747_AddUserAccountBranchSelections")]
+    partial class AddUserAccountBranchSelections
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/AccountingSystem/Migrations/20250921202747_AddUserAccountBranchSelections.cs
+++ b/AccountingSystem/Migrations/20250921202747_AddUserAccountBranchSelections.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AccountingSystem.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserAccountBranchSelections : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "BusinessAccountBranchIds",
+                table: "AspNetUsers",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "DriverAccountBranchIds",
+                table: "AspNetUsers",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "BusinessAccountBranchIds",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "DriverAccountBranchIds",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/AccountingSystem/Models/User.cs
+++ b/AccountingSystem/Models/User.cs
@@ -24,6 +24,8 @@ namespace AccountingSystem.Models
 
         public int? PaymentAccountId { get; set; }
         public int? PaymentBranchId { get; set; }
+        public string? DriverAccountBranchIds { get; set; }
+        public string? BusinessAccountBranchIds { get; set; }
         public decimal ExpenseLimit { get; set; } = 0;
 
         // Navigation properties

--- a/AccountingSystem/ViewModels/UserViewModels.cs
+++ b/AccountingSystem/ViewModels/UserViewModels.cs
@@ -63,8 +63,12 @@ namespace AccountingSystem.ViewModels
         public List<int> BranchIds { get; set; } = new List<int>();
         public int? PaymentBranchId { get; set; }
         public decimal ExpenseLimit { get; set; }
+        public List<int> DriverAccountBranchIds { get; set; } = new List<int>();
+        public List<int> BusinessAccountBranchIds { get; set; } = new List<int>();
         public List<SelectListItem> Branches { get; set; } = new List<SelectListItem>();
         public List<SelectListItem> PaymentBranches { get; set; } = new List<SelectListItem>();
+        public List<SelectListItem> DriverBranches { get; set; } = new List<SelectListItem>();
+        public List<SelectListItem> BusinessBranches { get; set; } = new List<SelectListItem>();
         public List<UserCurrencyAccountViewModel> CurrencyAccounts { get; set; } = new List<UserCurrencyAccountViewModel>();
     }
 
@@ -90,8 +94,12 @@ namespace AccountingSystem.ViewModels
         public List<int> BranchIds { get; set; } = new List<int>();
         public int? PaymentBranchId { get; set; }
         public decimal ExpenseLimit { get; set; }
+        public List<int> DriverAccountBranchIds { get; set; } = new List<int>();
+        public List<int> BusinessAccountBranchIds { get; set; } = new List<int>();
         public List<SelectListItem> Branches { get; set; } = new List<SelectListItem>();
         public List<SelectListItem> PaymentBranches { get; set; } = new List<SelectListItem>();
+        public List<SelectListItem> DriverBranches { get; set; } = new List<SelectListItem>();
+        public List<SelectListItem> BusinessBranches { get; set; } = new List<SelectListItem>();
         public List<UserCurrencyAccountViewModel> CurrencyAccounts { get; set; } = new List<UserCurrencyAccountViewModel>();
     }
 

--- a/AccountingSystem/Views/Users/Create.cshtml
+++ b/AccountingSystem/Views/Users/Create.cshtml
@@ -37,6 +37,14 @@
             <span asp-validation-for="BranchIds" class="text-danger"></span>
         </div>
         <div class="mb-3">
+            <label class="form-label">فروع حساب السائق</label>
+            <select asp-for="DriverAccountBranchIds" asp-items="Model.DriverBranches" class="form-select" multiple></select>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">فروع حساب البزنس</label>
+            <select asp-for="BusinessAccountBranchIds" asp-items="Model.BusinessBranches" class="form-select" multiple></select>
+        </div>
+        <div class="mb-3">
             <label asp-for="PaymentBranchId" class="form-label"></label>
             <select asp-for="PaymentBranchId" asp-items="Model.PaymentBranches" class="form-select">
                 <option value="">-- اختر فرع الدفع --</option>

--- a/AccountingSystem/Views/Users/Edit.cshtml
+++ b/AccountingSystem/Views/Users/Edit.cshtml
@@ -33,6 +33,14 @@
             <span asp-validation-for="BranchIds" class="text-danger"></span>
         </div>
         <div class="mb-3">
+            <label class="form-label">فروع حساب السائق</label>
+            <select asp-for="DriverAccountBranchIds" asp-items="Model.DriverBranches" class="form-select" multiple></select>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">فروع حساب البزنس</label>
+            <select asp-for="BusinessAccountBranchIds" asp-items="Model.BusinessBranches" class="form-select" multiple></select>
+        </div>
+        <div class="mb-3">
             <label asp-for="PaymentBranchId" class="form-label"></label>
             <select asp-for="PaymentBranchId" asp-items="Model.PaymentBranches" class="form-select">
                 <option value="">-- اختر فرع الدفع --</option>


### PR DESCRIPTION
## Summary
- add driver and business branch selection columns on the user entity
- allow the UsersController create/edit flows to populate and persist the new multi-branch selections
- extend the user create/edit forms and add a migration so the new selections are stored in the database

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68d05e2047948333ba36d1bd70fc0c2f