### PR TITLE
Implement automatic asset account creation with opening balance entry

### DIFF
--- a/AccountingSystem/Data/ApplicationDbContext.cs
+++ b/AccountingSystem/Data/ApplicationDbContext.cs
@@ -192,10 +192,16 @@ namespace AccountingSystem.Data
                 entity.Property(e => e.Type).IsRequired().HasMaxLength(100);
                 entity.Property(e => e.AssetNumber).HasMaxLength(100);
                 entity.Property(e => e.Notes).HasMaxLength(500);
+                entity.Property(e => e.OpeningBalance).HasColumnType("decimal(18,2)");
 
                 entity.HasOne(e => e.Branch)
                     .WithMany(b => b.Assets)
                     .HasForeignKey(e => e.BranchId)
+                    .OnDelete(DeleteBehavior.Restrict);
+
+                entity.HasOne(e => e.Account)
+                    .WithMany()
+                    .HasForeignKey(e => e.AccountId)
                     .OnDelete(DeleteBehavior.Restrict);
             });
 

--- a/AccountingSystem/Data/SeedData.cs
+++ b/AccountingSystem/Data/SeedData.cs
@@ -311,6 +311,11 @@ namespace AccountingSystem.Data
                 context.SystemSettings.Add(new SystemSetting { Key = "CashBoxDifferenceAccountId", Value = null });
             }
 
+            if (!context.SystemSettings.Any(s => s.Key == "AssetsParentAccountCode"))
+            {
+                context.SystemSettings.Add(new SystemSetting { Key = "AssetsParentAccountCode", Value = null });
+            }
+
             await context.SaveChangesAsync();
         }
 

--- a/AccountingSystem/Migrations/20251010120001_AddAssetAccountingFields.Designer.cs
+++ b/AccountingSystem/Migrations/20251010120001_AddAssetAccountingFields.Designer.cs
@@ -4,6 +4,7 @@ using AccountingSystem.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AccountingSystem.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251010120001_AddAssetAccountingFields")]
+    partial class AddAssetAccountingFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/AccountingSystem/Migrations/20251010120001_AddAssetAccountingFields.cs
+++ b/AccountingSystem/Migrations/20251010120001_AddAssetAccountingFields.cs
@@ -1,0 +1,60 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AccountingSystem.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAssetAccountingFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "AccountId",
+                table: "Assets",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "OpeningBalance",
+                table: "Assets",
+                type: "decimal(18,2)",
+                nullable: false,
+                defaultValue: 0m);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Assets_AccountId",
+                table: "Assets",
+                column: "AccountId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Assets_Accounts_AccountId",
+                table: "Assets",
+                column: "AccountId",
+                principalTable: "Accounts",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Assets_Accounts_AccountId",
+                table: "Assets");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Assets_AccountId",
+                table: "Assets");
+
+            migrationBuilder.DropColumn(
+                name: "AccountId",
+                table: "Assets");
+
+            migrationBuilder.DropColumn(
+                name: "OpeningBalance",
+                table: "Assets");
+        }
+    }
+}

--- a/AccountingSystem/Models/Asset.cs
+++ b/AccountingSystem/Models/Asset.cs
@@ -25,11 +25,17 @@ namespace AccountingSystem.Models
         [StringLength(500)]
         public string? Notes { get; set; }
 
+        public decimal OpeningBalance { get; set; }
+
+        public int? AccountId { get; set; }
+
         public DateTime CreatedAt { get; set; } = DateTime.Now;
 
         public DateTime? UpdatedAt { get; set; }
 
         public virtual Branch Branch { get; set; } = null!;
+
+        public virtual Account? Account { get; set; }
 
         public virtual ICollection<AssetExpense> Expenses { get; set; } = new List<AssetExpense>();
     }

--- a/AccountingSystem/ViewModels/AssetViewModels.cs
+++ b/AccountingSystem/ViewModels/AssetViewModels.cs
@@ -14,6 +14,7 @@ namespace AccountingSystem.ViewModels
         public string BranchName { get; set; } = string.Empty;
         public string? AssetNumber { get; set; }
         public string? Notes { get; set; }
+        public decimal OpeningBalance { get; set; }
         public DateTime CreatedAt { get; set; }
         public DateTime? UpdatedAt { get; set; }
     }
@@ -44,7 +45,21 @@ namespace AccountingSystem.ViewModels
         [Display(Name = "ملاحظات")]
         public string? Notes { get; set; }
 
+        [Display(Name = "الرصيد الافتتاحي")]
+        [Range(typeof(decimal), "0", "79228162514264337593543950335", ErrorMessage = "قيمة غير صالحة")]
+        public decimal OpeningBalance { get; set; }
+
+        [Required]
+        [Display(Name = "حساب رأس المال")]
+        public int CapitalAccountId { get; set; }
+
+        public int? AccountId { get; set; }
+
+        [Display(Name = "حساب الأصل")]
+        public string? AccountCode { get; set; }
+
         public IEnumerable<SelectListItem> Branches { get; set; } = Enumerable.Empty<SelectListItem>();
+        public IEnumerable<SelectListItem> CapitalAccounts { get; set; } = Enumerable.Empty<SelectListItem>();
     }
 
     public class AssetExpenseListViewModel

--- a/AccountingSystem/Views/Assets/Create.cshtml
+++ b/AccountingSystem/Views/Assets/Create.cshtml
@@ -28,6 +28,18 @@
                     <span asp-validation-for="BranchId" class="text-danger"></span>
                 </div>
                 <div class="col-md-6">
+                    <label asp-for="OpeningBalance" class="form-label"></label>
+                    <input asp-for="OpeningBalance" class="form-control" />
+                    <span asp-validation-for="OpeningBalance" class="text-danger"></span>
+                </div>
+                <div class="col-md-6">
+                    <label asp-for="CapitalAccountId" class="form-label"></label>
+                    <select asp-for="CapitalAccountId" asp-items="Model.CapitalAccounts" class="form-select">
+                        <option value="">اختر حساب رأس المال</option>
+                    </select>
+                    <span asp-validation-for="CapitalAccountId" class="text-danger"></span>
+                </div>
+                <div class="col-md-6">
                     <label asp-for="AssetNumber" class="form-label"></label>
                     <input asp-for="AssetNumber" class="form-control" />
                     <span asp-validation-for="AssetNumber" class="text-danger"></span>

--- a/AccountingSystem/Views/Assets/Edit.cshtml
+++ b/AccountingSystem/Views/Assets/Edit.cshtml
@@ -13,6 +13,7 @@
         <div class="card-body">
             <form asp-action="Edit" method="post" class="row g-3">
                 <input type="hidden" asp-for="Id" />
+                <input type="hidden" asp-for="AccountId" />
                 <div class="col-md-6">
                     <label asp-for="Name" class="form-label"></label>
                     <input asp-for="Name" class="form-control" />
@@ -27,6 +28,15 @@
                     <label asp-for="BranchId" class="form-label"></label>
                     <select asp-for="BranchId" asp-items="Model.Branches" class="form-select"></select>
                     <span asp-validation-for="BranchId" class="text-danger"></span>
+                </div>
+                <div class="col-md-6">
+                    <label asp-for="OpeningBalance" class="form-label"></label>
+                    <input asp-for="OpeningBalance" class="form-control" readonly />
+                    <span asp-validation-for="OpeningBalance" class="text-danger"></span>
+                </div>
+                <div class="col-md-6">
+                    <label asp-for="AccountCode" class="form-label"></label>
+                    <input asp-for="AccountCode" class="form-control" readonly />
                 </div>
                 <div class="col-md-6">
                     <label asp-for="AssetNumber" class="form-label"></label>


### PR DESCRIPTION
## Summary
- add opening balance capture and capital account selection when creating assets
- automatically create an asset ledger account, persist the link, and post the opening balance journal entry
- seed the asset parent account setting and add a migration for the new asset fields

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d701a330ec83339e2a8a920d7dda99