### PR TITLE
Add supplier support to asset asset expense workflow

### DIFF
--- a/AccountingSystem/Data/ApplicationDbContext.cs
+++ b/AccountingSystem/Data/ApplicationDbContext.cs
@@ -221,6 +221,11 @@ namespace AccountingSystem.Data
                     .HasForeignKey(e => e.AccountId)
                     .OnDelete(DeleteBehavior.Restrict);
 
+                entity.HasOne(e => e.Supplier)
+                    .WithMany()
+                    .HasForeignKey(e => e.SupplierId)
+                    .OnDelete(DeleteBehavior.Restrict);
+
                 entity.HasOne(e => e.Currency)
                     .WithMany()
                     .HasForeignKey(e => e.CurrencyId)

--- a/AccountingSystem/Migrations/20250926120000_AddSupplierToAssetExpenses.Designer.cs
+++ b/AccountingSystem/Migrations/20250926120000_AddSupplierToAssetExpenses.Designer.cs
@@ -4,6 +4,7 @@ using AccountingSystem.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AccountingSystem.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250926120000_AddSupplierToAssetExpenses")]
+    partial class AddSupplierToAssetExpenses
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/AccountingSystem/Migrations/20250926120000_AddSupplierToAssetExpenses.cs
+++ b/AccountingSystem/Migrations/20250926120000_AddSupplierToAssetExpenses.cs
@@ -1,0 +1,60 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AccountingSystem.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSupplierToAssetExpenses : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "SupplierId",
+                table: "AssetExpenses",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.Sql(@"
+                IF EXISTS (SELECT 1 FROM AssetExpenses WHERE SupplierId = 0)
+                BEGIN
+                    DECLARE @FirstSupplierId INT = (SELECT TOP 1 Id FROM Suppliers ORDER BY Id);
+                    IF @FirstSupplierId IS NOT NULL
+                    BEGIN
+                        UPDATE AssetExpenses SET SupplierId = @FirstSupplierId WHERE SupplierId = 0;
+                    END
+                END");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AssetExpenses_SupplierId",
+                table: "AssetExpenses",
+                column: "SupplierId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_AssetExpenses_Suppliers_SupplierId",
+                table: "AssetExpenses",
+                column: "SupplierId",
+                principalTable: "Suppliers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_AssetExpenses_Suppliers_SupplierId",
+                table: "AssetExpenses");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AssetExpenses_SupplierId",
+                table: "AssetExpenses");
+
+            migrationBuilder.DropColumn(
+                name: "SupplierId",
+                table: "AssetExpenses");
+        }
+    }
+}

--- a/AccountingSystem/Models/AssetExpense.cs
+++ b/AccountingSystem/Models/AssetExpense.cs
@@ -17,6 +17,9 @@ namespace AccountingSystem.Models
         public int? AccountId { get; set; }
 
         [Required]
+        public int SupplierId { get; set; }
+
+        [Required]
         public int CurrencyId { get; set; }
 
         [Column(TypeName = "decimal(18,2)")]
@@ -40,6 +43,8 @@ namespace AccountingSystem.Models
         public virtual Account ExpenseAccount { get; set; } = null!;
 
         public virtual Account? Account { get; set; }
+
+        public virtual Supplier Supplier { get; set; } = null!;
 
         public virtual Currency Currency { get; set; } = null!;
 

--- a/AccountingSystem/ViewModels/AssetViewModels.cs
+++ b/AccountingSystem/ViewModels/AssetViewModels.cs
@@ -53,6 +53,7 @@ namespace AccountingSystem.ViewModels
         public string AssetName { get; set; } = string.Empty;
         public string BranchName { get; set; } = string.Empty;
         public string ExpenseAccountName { get; set; } = string.Empty;
+        public string SupplierName { get; set; } = string.Empty;
         public decimal Amount { get; set; }
         public bool IsCash { get; set; }
         public DateTime Date { get; set; }
@@ -71,6 +72,10 @@ namespace AccountingSystem.ViewModels
 
         [Display(Name = "حساب التسوية")]
         public int? AccountId { get; set; }
+
+        [Required]
+        [Display(Name = "المورد")]
+        public int? SupplierId { get; set; }
 
         [Display(Name = "العملة")]
         public int CurrencyId { get; set; }
@@ -95,12 +100,22 @@ namespace AccountingSystem.ViewModels
         public IEnumerable<SelectListItem> Assets { get; set; } = Enumerable.Empty<SelectListItem>();
         public IEnumerable<AssetExpenseAccountOption> ExpenseAccounts { get; set; } = Enumerable.Empty<AssetExpenseAccountOption>();
         public IEnumerable<AssetExpenseAccountOption> Accounts { get; set; } = Enumerable.Empty<AssetExpenseAccountOption>();
+        public IEnumerable<AssetExpenseSupplierOption> Suppliers { get; set; } = Enumerable.Empty<AssetExpenseSupplierOption>();
     }
 
     public class AssetExpenseAccountOption
     {
         public int Id { get; set; }
         public string DisplayName { get; set; } = string.Empty;
+        public int CurrencyId { get; set; }
+        public string CurrencyCode { get; set; } = string.Empty;
+    }
+
+    public class AssetExpenseSupplierOption
+    {
+        public int Id { get; set; }
+        public string DisplayName { get; set; } = string.Empty;
+        public int AccountId { get; set; }
         public int CurrencyId { get; set; }
         public string CurrencyCode { get; set; } = string.Empty;
     }

--- a/AccountingSystem/Views/AssetExpenses/Create.cshtml
+++ b/AccountingSystem/Views/AssetExpenses/Create.cshtml
@@ -34,6 +34,21 @@
                     <span asp-validation-for="ExpenseAccountId" class="text-danger"></span>
                 </div>
                 <div class="col-md-6">
+                    <label asp-for="SupplierId" class="form-label"></label>
+                    <select asp-for="SupplierId" class="form-select" id="supplierSelect">
+                        <option value="">-- اختر المورد --</option>
+                        @foreach (var supplier in Model.Suppliers)
+                        {
+                            <option value="@supplier.Id"
+                                    data-account-id="@supplier.AccountId"
+                                    data-currency-id="@supplier.CurrencyId"
+                                    data-currency-code="@supplier.CurrencyCode"
+                                    selected="@(Model.SupplierId.HasValue && supplier.Id == Model.SupplierId.Value ? "selected" : null)">@supplier.DisplayName</option>
+                        }
+                    </select>
+                    <span asp-validation-for="SupplierId" class="text-danger"></span>
+                </div>
+                <div class="col-md-6">
                     <label asp-for="IsCash" class="form-label"></label>
                     <select asp-for="IsCash" class="form-select" id="paymentType">
                         <option value="true" selected="@(Model.IsCash ? "selected" : null)">نقدي</option>
@@ -98,6 +113,7 @@
             const paymentType = document.getElementById('paymentType');
             const currencyDisplay = document.getElementById('currencyDisplay');
             const currencyId = document.getElementById('currencyId');
+            const supplierSelect = document.getElementById('supplierSelect');
 
             function updateCurrency() {
                 if (!expenseSelect) return;
@@ -107,6 +123,7 @@
                 currencyDisplay.value = currencyCode || '';
                 currencyId.value = currencyValue || '';
                 filterSettlementAccounts(currencyValue);
+                filterSuppliers(currencyValue);
             }
 
             function filterSettlementAccounts(currencyValue) {
@@ -125,6 +142,25 @@
                 });
                 if (firstVisible && settlementSelect.value && settlementSelect.options[settlementSelect.selectedIndex].hidden) {
                     settlementSelect.value = firstVisible.value;
+                }
+            }
+
+            function filterSuppliers(currencyValue) {
+                if (!supplierSelect) return;
+                let firstVisible = null;
+                Array.from(supplierSelect.options).forEach(opt => {
+                    if (!opt.value) {
+                        opt.hidden = false;
+                        return;
+                    }
+                    const matches = !currencyValue || opt.getAttribute('data-currency-id') === currencyValue;
+                    opt.hidden = !matches;
+                    if (matches && !firstVisible) {
+                        firstVisible = opt;
+                    }
+                });
+                if (firstVisible && supplierSelect.value && supplierSelect.options[supplierSelect.selectedIndex].hidden) {
+                    supplierSelect.value = firstVisible.value;
                 }
             }
 
@@ -147,6 +183,7 @@
 
             updateCurrency();
             toggleSettlement();
+            filterSuppliers(currencyId.value);
         });
     </script>
 }

--- a/AccountingSystem/Views/AssetExpenses/Index.cshtml
+++ b/AccountingSystem/Views/AssetExpenses/Index.cshtml
@@ -23,6 +23,7 @@
                                 <th>الأصل</th>
                                 <th>الفرع</th>
                                 <th>الحساب</th>
+                                <th>المورد</th>
                                 <th>المبلغ</th>
                                 <th>نوع الدفع</th>
                                 <th>التاريخ</th>
@@ -36,6 +37,7 @@
                                     <td>@item.AssetName</td>
                                     <td>@item.BranchName</td>
                                     <td>@item.ExpenseAccountName</td>
+                                    <td>@item.SupplierName</td>
                                     <td>@item.Amount.ToString("N2")</td>
                                     <td>@(item.IsCash ? "نقدي" : "غير نقدي")</td>
                                     <td>@item.Date.ToString("yyyy-MM-dd")</td>


### PR DESCRIPTION
## Summary
- require selecting a supplier when creating an asset expense and post supplier-aware journal lines, including immediate settlement for cash and optional account payments
- extend asset expense view models and pages to capture/filter suppliers and show the linked supplier in listings
- add a migration wiring AssetExpenses to Suppliers with a foreign key and index

## Testing
- dotnet build *(fails: `dotnet` command is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d70217f2748333ad9c0a37a589c428