### PR TITLE
Fix payment voucher creation without manual exchange rate

### DIFF
--- a/AccountingSystem/Controllers/PaymentVouchersController.cs
+++ b/AccountingSystem/Controllers/PaymentVouchersController.cs
@@ -95,6 +95,8 @@ namespace AccountingSystem.Controllers
                     ModelState.AddModelError("AccountId", "يجب أن تكون الحسابات بنفس العملة");
             }
 
+            ModelState.Remove(nameof(PaymentVoucher.ExchangeRate));
+
             if (!ModelState.IsValid)
             {
                 ViewBag.Suppliers = await _context.Suppliers
@@ -120,11 +122,8 @@ namespace AccountingSystem.Controllers
             }
 
             model.CurrencyId = supplier!.Account!.CurrencyId;
-            if (model.ExchangeRate <= 0)
-            {
-                var currency = await _context.Currencies.FindAsync(model.CurrencyId);
-                model.ExchangeRate = currency?.ExchangeRate ?? 1m;
-            }
+            var currency = await _context.Currencies.FindAsync(model.CurrencyId);
+            model.ExchangeRate = currency?.ExchangeRate ?? 1m;
 
             model.CreatedById = user.Id;
             _context.PaymentVouchers.Add(model);

--- a/AccountingSystem/Views/PaymentVouchers/Create.cshtml
+++ b/AccountingSystem/Views/PaymentVouchers/Create.cshtml
@@ -36,10 +36,7 @@
             <input type="text" class="form-control" id="currencyDisplay" readonly />
             <input type="hidden" asp-for="CurrencyId" id="currencyId" />
         </div>
-        <div class="col-md-6">
-            <label class="form-label">سعر الصرف</label>
-            <input asp-for="ExchangeRate" class="form-control" />
-        </div>
+        <input asp-for="ExchangeRate" type="hidden" value="1" />
         <div class="col-md-6">
             <label class="form-label">المبلغ</label>
             <input asp-for="Amount" class="form-control" />


### PR DESCRIPTION
## Summary
- ignore client-side exchange rate validation errors so payment vouchers can be saved without manual input
- hide the exchange rate field in the create voucher form and default it server-side to the supplier currency rate

## Testing
- dotnet build *(fails: dotnet not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d70c91d4688333baa4a06b8e4401fb