### PR TITLE
Add AJAX journal entries listing with filters and printing

### DIFF
--- a/AccountingSystem/ViewModels/SimpleViewModels.cs
+++ b/AccountingSystem/ViewModels/SimpleViewModels.cs
@@ -399,6 +399,18 @@ namespace AccountingSystem.ViewModels
         public string BranchName { get; set; } = string.Empty;
         public decimal TotalAmount { get; set; }
         public int LinesCount { get; set; }
+        public string StatusDisplay { get; set; } = string.Empty;
+        public string StatusClass { get; set; } = string.Empty;
+        public string DateFormatted { get; set; } = string.Empty;
+        public string DateGroup { get; set; } = string.Empty;
+        public string TotalAmountFormatted { get; set; } = string.Empty;
+        public bool IsDraft { get; set; }
+    }
+
+    public class JournalEntriesIndexViewModel
+    {
+        public List<SelectListItem> Branches { get; set; } = new List<SelectListItem>();
+        public List<SelectListItem> Statuses { get; set; } = new List<SelectListItem>();
     }
 
     // User Index ViewModels

--- a/AccountingSystem/Views/JournalEntries/Index.cshtml
+++ b/AccountingSystem/Views/JournalEntries/Index.cshtml
@@ -1,125 +1,366 @@
-@model AccountingSystem.ViewModels.PagedResult<AccountingSystem.ViewModels.JournalEntryViewModel>
+@using System.Linq
+@model AccountingSystem.ViewModels.JournalEntriesIndexViewModel
 
 @{
     ViewData["Title"] = "القيود المالية";
     Layout = "~/Views/Shared/_AccountingLayout.cshtml";
 }
 
+@section Styles {
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css" />
+    <link rel="stylesheet" href="https://cdn.datatables.net/buttons/2.4.1/css/buttons.bootstrap5.min.css" />
+    <link rel="stylesheet" href="https://cdn.datatables.net/rowgroup/1.3.1/css/rowGroup.bootstrap5.min.css" />
+    <style>
+        .dt-buttons .btn {
+            margin-left: .5rem;
+            margin-right: .5rem;
+        }
+
+        table.dataTable tbody tr.group-header td {
+            background-color: #f1f3f5;
+            font-weight: 700;
+            color: #0d6efd;
+        }
+
+        #journalEntriesTable thead tr.filters-row th {
+            background-color: #f8f9fa;
+            font-weight: 400;
+        }
+
+        #journalEntriesTable thead input,
+        #journalEntriesTable thead select {
+            max-width: 100%;
+        }
+
+        .dataTables_wrapper .dataTables_processing {
+            top: 50%;
+            z-index: 1000;
+        }
+
+        .table-actions .btn {
+            margin-inline-start: .25rem;
+            margin-inline-end: .25rem;
+        }
+    </style>
+}
+
 <div class="container-fluid">
     <div class="row">
         <div class="col-12">
-            <div class="card">
-                <div class="card-header d-flex justify-content-between align-items-center">
+            <div class="card shadow-sm">
+                <div class="card-header d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-2">
                     <h3 class="card-title mb-0">
                         <i class="fas fa-file-invoice me-2"></i>
                         القيود المالية
                     </h3>
-                    <a asp-action="Create" class="btn btn-primary">
-                        <i class="fas fa-plus me-1"></i>
-                        إضافة قيد جديد
-                    </a>
+                    <div class="d-flex flex-column flex-md-row align-items-md-center gap-2">
+                        <a asp-action="Create" class="btn btn-primary">
+                            <i class="fas fa-plus me-1"></i>
+                            إضافة قيد جديد
+                        </a>
+                    </div>
                 </div>
                 <div class="card-body">
-                    <form method="get" class="row mb-3">
-                        <div class="col-md-4 ms-auto">
-                            <input type="text" name="searchTerm" value="@Model.SearchTerm" class="form-control" placeholder="البحث في القيود..." />
+                    <form id="filtersForm" class="row g-3 align-items-end mb-3">
+                        <div class="col-sm-6 col-lg-3">
+                            <label for="fromDate" class="form-label">من تاريخ</label>
+                            <input type="date" id="fromDate" class="form-control" />
                         </div>
-                        <div class="col-md-2">
-                            <button type="submit" class="btn btn-secondary w-100">بحث</button>
+                        <div class="col-sm-6 col-lg-3">
+                            <label for="toDate" class="form-label">إلى تاريخ</label>
+                            <input type="date" id="toDate" class="form-control" />
+                        </div>
+                        <div class="col-sm-6 col-lg-3">
+                            <label for="branchFilter" class="form-label">الفرع</label>
+                            <select id="branchFilter" class="form-select">
+                                @foreach (var branch in Model.Branches)
+                                {
+                                    <option value="@branch.Value">@branch.Text</option>
+                                }
+                            </select>
+                        </div>
+                        <div class="col-sm-6 col-lg-3">
+                            <label for="statusFilter" class="form-label">الحالة</label>
+                            <select id="statusFilter" class="form-select">
+                                @foreach (var status in Model.Statuses)
+                                {
+                                    <option value="@status.Value">@status.Text</option>
+                                }
+                            </select>
+                        </div>
+                        <div class="col-sm-6 col-lg-3">
+                            <label for="groupBy" class="form-label">تجميع النتائج</label>
+                            <select id="groupBy" class="form-select">
+                                <option value="">بدون تجميع</option>
+                                <option value="branchName">حسب الفرع</option>
+                                <option value="statusDisplay">حسب الحالة</option>
+                                <option value="dateGroup">حسب الشهر</option>
+                            </select>
+                        </div>
+                        <div class="col-sm-6 col-lg-3 d-flex">
+                            <button type="button" id="resetFilters" class="btn btn-outline-secondary w-100 mt-auto">
+                                <i class="fas fa-undo"></i> إعادة تعيين
+                            </button>
                         </div>
                     </form>
 
-                    @if (Model.Items.Any())
-                    {
-                        <div class="table-responsive">
-                            <table class="table table-striped table-hover">
-                                <thead class="table-dark">
-                                    <tr>
-                                        <th>رقم القيد</th>
-                                        <th>التاريخ</th>
-                                        <th>الوصف</th>
-                                        <th>المرجع</th>
-                                        <th>الفرع</th>
-                                        <th>المبلغ الإجمالي</th>
-                                        <th>عدد البنود</th>
-                                        <th>الحالة</th>
-                                        <th>الإجراءات</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    @foreach (var entry in Model.Items)
-                                    {
-                                        <tr>
-                                            <td>@entry.Number</td>
-                                            <td>@entry.Date.ToString("yyyy-MM-dd")</td>
-                                            <td>@entry.Description</td>
-                                            <td>@entry.Reference</td>
-                                            <td>@entry.BranchName</td>
-                                            <td>@entry.TotalAmount.ToString("N2") </td>
-                                            <td>@entry.LinesCount</td>
-                                            <td>
-                                                @switch (entry.Status)
-                                                {
-                                                    case "Draft":
-                                                        <span class="badge bg-secondary">مسودة</span>
-                                                        break;
-                                                    case "Posted":
-                                                        <span class="badge bg-success">مرحل</span>
-                                                        break;
-                                                    case "Approved":
-                                                        <span class="badge bg-primary">معتمد</span>
-                                                        break;
-                                                    case "Cancelled":
-                                                        <span class="badge bg-danger">ملغي</span>
-                                                        break;
-                                                    default:
-                                                        <span class="badge bg-secondary">@entry.Status</span>
-                                                        break;
-                                                }
-                                            </td>
-                                            <td>
-                                                <div class="btn-group" role="group">
-                                                    <a asp-action="Details" asp-route-id="@entry.Id" class="btn btn-sm btn-outline-info">
-                                                        <i class="fas fa-eye"></i>
-                                                    </a>
-                                                    @if (entry.Status == "Draft")
-                                                    {
-                                                        <a asp-action="Edit" asp-route-id="@entry.Id" class="btn btn-sm btn-outline-warning">
-                                                            <i class="fas fa-edit"></i>
-                                                        </a>
-                                                        <form asp-action="Post" asp-route-id="@entry.Id" method="post" class="d-inline">
-                                                            <button type="submit" class="btn btn-sm btn-outline-success">
-                                                                <i class="fas fa-share"></i>
-                                                            </button>
-                                                        </form>
-                                                    }
-                                                </div>
-                                            </td>
-                                        </tr>
-                                    }
-                                </tbody>
-                            </table>
-                        </div>
-                        <nav>
-                            <ul class="pagination justify-content-center mt-3">
-                                @for (int i = 1; i <= Model.TotalPages; i++)
-                                {
-                                    <li class="page-item @(i == Model.Page ? "active" : "")">
-                                        <a class="page-link" href="?page=@i&searchTerm=@Model.SearchTerm">@i</a>
-                                    </li>
-                                }
-                            </ul>
-                        </nav>
-                    }
-                    else
-                    {
-                        <div class="alert alert-info text-center">
-                            <i class="fas fa-info-circle"></i>
-                            لا توجد قيود مسجلة
-                        </div>
-                    }
+                    <div class="table-responsive">
+                        <table id="journalEntriesTable" class="table table-striped table-hover align-middle w-100">
+                            <thead>
+                                <tr>
+                                    <th>رقم القيد</th>
+                                    <th>التاريخ</th>
+                                    <th>الوصف</th>
+                                    <th>المرجع</th>
+                                    <th>الفرع</th>
+                                    <th>المبلغ الإجمالي</th>
+                                    <th>عدد البنود</th>
+                                    <th>الحالة</th>
+                                    <th>الإجراءات</th>
+                                </tr>
+                                <tr class="filters-row">
+                                    <th><input type="text" class="form-control form-control-sm column-search" data-column="0" placeholder="بحث..." /></th>
+                                    <th><input type="date" class="form-control form-control-sm column-search" data-column="1" /></th>
+                                    <th><input type="text" class="form-control form-control-sm column-search" data-column="2" placeholder="بحث..." /></th>
+                                    <th><input type="text" class="form-control form-control-sm column-search" data-column="3" placeholder="بحث..." /></th>
+                                    <th><input type="text" class="form-control form-control-sm column-search" data-column="4" placeholder="بحث..." /></th>
+                                    <th><input type="number" step="0.01" class="form-control form-control-sm column-search" data-column="5" placeholder="=" /></th>
+                                    <th><input type="number" class="form-control form-control-sm column-search" data-column="6" placeholder="=" /></th>
+                                    <th>
+                                        <select class="form-select form-select-sm column-search" data-column="7">
+                                            <option value="">الكل</option>
+                                            @foreach (var status in Model.Statuses.Where(s => !string.IsNullOrEmpty(s.Value)))
+                                            {
+                                                <option value="@status.Value">@status.Text</option>
+                                            }
+                                        </select>
+                                    </th>
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody></tbody>
+                        </table>
+                    </div>
+
+                    <form id="antiForgeryForm" asp-action="Post" method="post" class="d-none">
+                        @Html.AntiForgeryToken()
+                    </form>
                 </div>
             </div>
         </div>
     </div>
 </div>
+
+@section Scripts {
+    <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
+    <script src="https://cdn.datatables.net/buttons/2.4.1/js/dataTables.buttons.min.js"></script>
+    <script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.bootstrap5.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
+    <script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.html5.min.js"></script>
+    <script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.print.min.js"></script>
+    <script src="https://cdn.datatables.net/rowgroup/1.3.1/js/dataTables.rowGroup.min.js"></script>
+    <script>
+        (function () {
+            const formatCurrency = value => new Intl.NumberFormat('ar-EG', {
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2
+            }).format(value ?? 0);
+
+            const detailsUrlBase = '@Url.Action("Details", "JournalEntries")';
+            const editUrlBase = '@Url.Action("Edit", "JournalEntries")';
+            const postUrlBase = '@Url.Action("Post", "JournalEntries")';
+            const printUrlBase = '@Url.Action("Print", "JournalEntries")';
+
+            const table = $('#journalEntriesTable').DataTable({
+                processing: true,
+                serverSide: true,
+                deferRender: true,
+                ajax: {
+                    url: '@Url.Action("GetEntries", "JournalEntries")',
+                    data: function (d) {
+                        d.fromDate = $('#fromDate').val();
+                        d.toDate = $('#toDate').val();
+                        d.branchId = $('#branchFilter').val();
+                        d.status = $('#statusFilter').val();
+                    }
+                },
+                columns: [
+                    { data: 'number' },
+                    { data: 'dateFormatted' },
+                    { data: 'description' },
+                    { data: 'reference' },
+                    { data: 'branchName' },
+                    {
+                        data: 'totalAmount',
+                        render: function (data, type) {
+                            if (type === 'display' || type === 'filter') {
+                                return `<span class="text-nowrap">${formatCurrency(data)}</span>`;
+                            }
+                            return data;
+                        },
+                        className: 'text-end'
+                    },
+                    { data: 'linesCount', className: 'text-center' },
+                    {
+                        data: 'statusDisplay',
+                        render: function (data, type, row) {
+                            if (type === 'display') {
+                                return `<span class="badge ${row.statusClass}">${data}</span>`;
+                            }
+                            return data;
+                        },
+                        className: 'text-center'
+                    },
+                    {
+                        data: null,
+                        orderable: false,
+                        searchable: false,
+                        className: 'text-center text-nowrap table-actions',
+                        render: function (data, type, row) {
+                            const detailsUrl = `${detailsUrlBase}/${row.id}`;
+                            const editUrl = `${editUrlBase}/${row.id}`;
+                            const printUrl = `${printUrlBase}/${row.id}`;
+
+                            let buttons = `
+                                <a href="${detailsUrl}" class="btn btn-sm btn-outline-info" title="عرض">
+                                    <i class="fas fa-eye"></i>
+                                </a>`;
+
+                            if (row.isDraft) {
+                                buttons += `
+                                    <a href="${editUrl}" class="btn btn-sm btn-outline-warning" title="تعديل">
+                                        <i class="fas fa-edit"></i>
+                                    </a>
+                                    <button type="button" class="btn btn-sm btn-outline-success btn-post-entry" data-id="${row.id}" data-number="${row.number}" title="ترحيل">
+                                        <i class="fas fa-share"></i>
+                                    </button>`;
+                            }
+
+                            buttons += `
+                                <a href="${printUrl}" target="_blank" class="btn btn-sm btn-outline-secondary" title="طباعة">
+                                    <i class="fas fa-print"></i>
+                                </a>`;
+
+                            return `<div class="btn-group" role="group">${buttons}</div>`;
+                        }
+                    }
+                ],
+                order: [[1, 'desc']],
+                pageLength: 10,
+                lengthMenu: [[10, 25, 50, 100, -1], [10, 25, 50, 100, 'الكل']],
+                dom: "<'row mb-2'<'col-sm-12 col-md-4'l><'col-sm-12 col-md-4 text-center'B><'col-sm-12 col-md-4'f>>" +
+                    "<'row'<'col-sm-12'tr>>" +
+                    "<'row mt-2'<'col-sm-12 col-md-5'i><'col-sm-12 col-md-7'p>>",
+                buttons: [
+                    {
+                        extend: 'excelHtml5',
+                        text: '<i class="fas fa-file-excel me-2"></i>تصدير Excel',
+                        exportOptions: { columns: ':not(:last-child)' }
+                    },
+                    {
+                        extend: 'print',
+                        text: '<i class="fas fa-print me-2"></i>طباعة جميع القيود',
+                        title: 'القيود المالية',
+                        exportOptions: { columns: ':not(:last-child)' },
+                        customize: function (win) {
+                            $(win.document.body)
+                                .css('direction', 'rtl')
+                                .css('font-family', '\"Tajawal\", Arial, sans-serif');
+                            $(win.document.body).find('table')
+                                .addClass('table table-bordered')
+                                .css('direction', 'rtl');
+                        }
+                    }
+                ],
+                language: {
+                    url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/ar.json'
+                },
+                rowGroup: {
+                    dataSrc: 'branchName',
+                    startRender: function (rows, group) {
+                        const total = rows
+                            .data()
+                            .pluck('totalAmount')
+                            .reduce((a, b) => a + parseFloat(b || 0), 0);
+                        return $('<tr/>')
+                            .addClass('group-header')
+                            .append(`<td colspan="9">${group} - إجمالي: ${formatCurrency(total)}</td>`);
+                    }
+                }
+            });
+
+            table.rowGroup().disable();
+
+            table.on('preXhr.dt', function () { showLoading(); });
+            table.on('xhr.dt', function () { hideLoading(); });
+            table.on('error.dt', function () { hideLoading(); });
+
+            $('.column-search').on('change keyup', function () {
+                const columnIndex = $(this).data('column');
+                const value = $(this).val();
+                table.column(columnIndex).search(value || '').draw();
+            });
+
+            $('#fromDate, #toDate, #branchFilter, #statusFilter').on('change', function () {
+                table.ajax.reload();
+            });
+
+            $('#resetFilters').on('click', function () {
+                $('#fromDate, #toDate').val('');
+                $('#branchFilter option:first').prop('selected', true);
+                $('#statusFilter option:first').prop('selected', true);
+                $('#groupBy').val('');
+                $('.column-search').each(function () {
+                    $(this).val('');
+                    const columnIndex = $(this).data('column');
+                    table.column(columnIndex).search('');
+                });
+                table.rowGroup().disable();
+                table.ajax.reload();
+            });
+
+            $('#groupBy').on('change', function () {
+                const value = $(this).val();
+                if (value) {
+                    table.rowGroup().dataSrc(value).enable();
+                } else {
+                    table.rowGroup().disable();
+                }
+                table.draw();
+            });
+
+            $('#journalEntriesTable').on('click', '.btn-post-entry', function () {
+                const id = $(this).data('id');
+                const number = $(this).data('number');
+                if (!confirm(`هل تريد ترحيل القيد رقم ${number}?`)) {
+                    return;
+                }
+
+                showLoading();
+                $.ajax({
+                    url: `${postUrlBase}/${id}`,
+                    type: 'POST',
+                    success: function () {
+                        hideLoading();
+                        table.ajax.reload(null, false);
+                        if (window.swal) {
+                            swal({ title: 'تم الترحيل بنجاح', icon: 'success', button: 'حسناً' });
+                        } else {
+                            alert('تم ترحيل القيد بنجاح');
+                        }
+                    },
+                    error: function (xhr) {
+                        hideLoading();
+                        const message = xhr.responseText || 'تعذر ترحيل القيد.';
+                        if (window.swal) {
+                            swal({ title: 'خطأ', text: message, icon: 'error', button: 'إغلاق' });
+                        } else {
+                            alert(message);
+                        }
+                    }
+                });
+            });
+        })();
+    </script>
+}

--- a/AccountingSystem/Views/JournalEntries/Print.cshtml
+++ b/AccountingSystem/Views/JournalEntries/Print.cshtml
@@ -1,0 +1,159 @@
+@model AccountingSystem.ViewModels.JournalEntryDetailsViewModel
+@{
+    Layout = null;
+}
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+    <meta charset="utf-8" />
+    <title>طباعة القيد @Model.Number</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.rtl.min.css" />
+    <style>
+        @page {
+            size: A4;
+            margin: 15mm;
+        }
+
+        body {
+            font-family: 'Tajawal', 'Segoe UI', sans-serif;
+            background-color: #fff;
+            color: #212529;
+        }
+
+        .print-container {
+            padding: 10px 25px;
+        }
+
+        .document-title {
+            font-size: 1.8rem;
+            font-weight: 700;
+            color: #0d6efd;
+        }
+
+        .info-table td {
+            padding: .35rem .5rem;
+            vertical-align: top;
+        }
+
+        .signature-box {
+            min-height: 80px;
+            border: 1px dashed #adb5bd;
+            padding: 0.75rem;
+            border-radius: .5rem;
+        }
+
+        .table thead {
+            background-color: #0d6efd;
+            color: #fff;
+        }
+
+        .table tbody tr:nth-child(even) {
+            background-color: #f8f9fa;
+        }
+
+        .badge-status {
+            padding: .4rem .8rem;
+            font-size: .9rem;
+        }
+    </style>
+</head>
+<body>
+    <div class="print-container">
+        <div class="d-flex justify-content-between align-items-center mb-4">
+            <div>
+                <h1 class="document-title mb-1">قيد محاسبي</h1>
+                <p class="text-muted mb-0">تاريخ الطباعة: @DateTime.Now.ToString("yyyy/MM/dd HH:mm")</p>
+            </div>
+            <div class="text-end">
+                <h5 class="mb-1">رقم القيد:</h5>
+                <h4 class="fw-bold">@Model.Number</h4>
+            </div>
+        </div>
+
+        <table class="table table-borderless info-table">
+            <tbody>
+                <tr>
+                    <td><strong>التاريخ:</strong> @Model.Date.ToString("yyyy/MM/dd")</td>
+                    <td><strong>الفرع:</strong> @Model.BranchName</td>
+                    <td><strong>المرجع:</strong> @Model.Reference</td>
+                </tr>
+                <tr>
+                    <td colspan="2"><strong>الوصف:</strong> @Model.Description</td>
+                    <td>
+                        <strong>الحالة:</strong>
+                        @switch (Model.Status)
+                        {
+                            case "Draft":
+                                <span class="badge bg-secondary badge-status">مسودة</span>
+                                break;
+                            case "Posted":
+                                <span class="badge bg-success badge-status">مرحل</span>
+                                break;
+                            case "Approved":
+                                <span class="badge bg-primary badge-status">معتمد</span>
+                                break;
+                            case "Cancelled":
+                                <span class="badge bg-danger badge-status">ملغي</span>
+                                break;
+                            default:
+                                <span class="badge bg-secondary badge-status">@Model.Status</span>
+                                break;
+                        }
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+
+        <table class="table table-bordered text-center align-middle">
+            <thead>
+                <tr>
+                    <th style="width: 15%;">الكود</th>
+                    <th style="width: 25%;">اسم الحساب</th>
+                    <th style="width: 30%;">البيان</th>
+                    <th style="width: 15%;">مدين</th>
+                    <th style="width: 15%;">دائن</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var line in Model.Lines)
+                {
+                    <tr>
+                        <td>@line.AccountCode</td>
+                        <td>@line.AccountName</td>
+                        <td class="text-start">@line.Description</td>
+                        <td>@line.DebitAmount.ToString("N2")</td>
+                        <td>@line.CreditAmount.ToString("N2")</td>
+                    </tr>
+                }
+            </tbody>
+            <tfoot class="table-light">
+                <tr>
+                    <th colspan="3" class="text-end">الإجمالي</th>
+                    <th>@Model.TotalDebit.ToString("N2")</th>
+                    <th>@Model.TotalCredit.ToString("N2")</th>
+                </tr>
+            </tfoot>
+        </table>
+
+        <div class="row mt-4">
+            <div class="col-sm-4">
+                <h6 class="fw-bold">إعداد</h6>
+                <div class="signature-box"></div>
+            </div>
+            <div class="col-sm-4">
+                <h6 class="fw-bold">مراجعة</h6>
+                <div class="signature-box"></div>
+            </div>
+            <div class="col-sm-4">
+                <h6 class="fw-bold">اعتماد</h6>
+                <div class="signature-box"></div>
+            </div>
+        </div>
+    </div>
+    <script>
+        window.addEventListener('load', function () {
+            window.print();
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace the journal entries index view with an AJAX-powered DataTable that supports column search, paging controls, date range filtering, dynamic grouping, and Excel/print exports
- add a JSON endpoint and helper methods in `JournalEntriesController` to serve DataTables requests, reuse detail mapping, and expose a print-friendly action
- extend the journal entry view models and add a dedicated A4 print view for individual entries

## Testing
- `dotnet build` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d70d91db9c833396530604138059b3