### PR TITLE
Prevent navigation property validation on payment vouchers

### DIFF
--- a/AccountingSystem/Models/PaymentVoucher.cs
+++ b/AccountingSystem/Models/PaymentVoucher.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 
 namespace AccountingSystem.Models
 {
@@ -31,9 +32,16 @@ namespace AccountingSystem.Models
 
         public bool IsCash { get; set; }
 
+        [ValidateNever]
         public virtual Supplier Supplier { get; set; } = null!;
+
+        [ValidateNever]
         public virtual Account? Account { get; set; }
+
+        [ValidateNever]
         public virtual Currency Currency { get; set; } = null!;
+
+        [ValidateNever]
         public virtual User CreatedBy { get; set; } = null!;
     }
 }


### PR DESCRIPTION
## Summary
- add model binding validation suppression for PaymentVoucher navigation properties
- ensure the Create view no longer fails validation when navigation properties are not posted

## Testing
- dotnet build *(fails: dotnet not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d71049a2848333bdfe21e1fb1bda9d