### PR TITLE
Update Syncfusion EJ2 packages to 31.1.21

### DIFF
--- a/AccountingSystem/AccountingSystem.csproj
+++ b/AccountingSystem/AccountingSystem.csproj
@@ -24,8 +24,8 @@
     <PackageReference Include="QuestPDF" Version="2025.7.1" />
     <PackageReference Include="Syncfusion.DocIO.Net.Core" Version="31.1.21" />
     <PackageReference Include="Syncfusion.DocIORenderer.Net.Core" Version="31.1.21" />
-    <PackageReference Include="Syncfusion.EJ2.AspNet.Core" Version="30.2.7" />
-    <PackageReference Include="Syncfusion.EJ2.PdfViewer.AspNet.Core.Windows" Version="28.1.37" />
+    <PackageReference Include="Syncfusion.EJ2.AspNet.Core" Version="31.1.21" />
+    <PackageReference Include="Syncfusion.EJ2.PdfViewer.AspNet.Core.Windows" Version="31.1.21" />
     <PackageReference Include="Syncfusion.Pdf.Net.Core" Version="31.1.21" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- align the Syncfusion EJ2 ASP.NET Core packages to version 31.1.21 so their licensing APIs match the other Syncfusion components and eliminate the MissingMethodException at runtime

## Testing
- not run (dotnet CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d71ab6d36c833397db90256041039b