### PR TITLE
Add dynamic Syncfusion pivot reporting

### DIFF
--- a/AccountingSystem/Data/ApplicationDbContext.cs
+++ b/AccountingSystem/Data/ApplicationDbContext.cs
@@ -44,6 +44,7 @@ namespace AccountingSystem.Data
         public DbSet<UserPaymentAccount> UserPaymentAccounts { get; set; }
         public DbSet<Asset> Assets { get; set; }
         public DbSet<AssetExpense> AssetExpenses { get; set; }
+        public DbSet<PivotReport> PivotReports { get; set; }
 
         public override int SaveChanges()
         {
@@ -241,6 +242,22 @@ namespace AccountingSystem.Data
                     .WithMany()
                     .HasForeignKey(e => e.CreatedById)
                     .OnDelete(DeleteBehavior.Restrict);
+            });
+
+            builder.Entity<PivotReport>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.Name).IsRequired().HasMaxLength(150);
+                entity.Property(e => e.Layout).IsRequired();
+                entity.Property(e => e.ReportType).IsRequired();
+                entity.Property(e => e.CreatedById).IsRequired();
+                entity.Property(e => e.CreatedAt).HasColumnType("datetime2");
+                entity.Property(e => e.UpdatedAt).HasColumnType("datetime2");
+
+                entity.HasOne(e => e.CreatedBy)
+                    .WithMany()
+                    .HasForeignKey(e => e.CreatedById)
+                    .OnDelete(DeleteBehavior.Cascade);
             });
 
             // JournalEntry configuration
@@ -591,7 +608,9 @@ namespace AccountingSystem.Data
                 new Permission { Id = 50, Name = "assets.edit", DisplayName = "تعديل الأصول", Category = "الأصول", CreatedAt = createdAt },
                 new Permission { Id = 51, Name = "assets.delete", DisplayName = "حذف الأصول", Category = "الأصول", CreatedAt = createdAt },
                 new Permission { Id = 52, Name = "assetexpenses.view", DisplayName = "عرض مصاريف الأصول", Category = "الأصول", CreatedAt = createdAt },
-                new Permission { Id = 53, Name = "assetexpenses.create", DisplayName = "إنشاء مصروف أصل", Category = "الأصول", CreatedAt = createdAt }
+                new Permission { Id = 53, Name = "assetexpenses.create", DisplayName = "إنشاء مصروف أصل", Category = "الأصول", CreatedAt = createdAt },
+                new Permission { Id = 54, Name = "reports.pending", DisplayName = "عرض الحركات غير المرحلة", Category = "التقارير", CreatedAt = createdAt },
+                new Permission { Id = 55, Name = "reports.dynamic", DisplayName = "التقارير التفاعلية", Category = "التقارير", CreatedAt = createdAt }
             );
         }
     }

--- a/AccountingSystem/Data/SeedData.cs
+++ b/AccountingSystem/Data/SeedData.cs
@@ -95,6 +95,7 @@ namespace AccountingSystem.Data
                 new Permission { Name = "reports.view", DisplayName = "عرض التقارير", Category = "التقارير" },
                 new Permission { Name = "reports.export", DisplayName = "تصدير التقارير", Category = "التقارير" },
                 new Permission { Name = "reports.pending", DisplayName = "عرض الحركات غير المرحلة", Category = "التقارير" },
+                new Permission { Name = "reports.dynamic", DisplayName = "التقارير التفاعلية", Category = "التقارير" },
                 new Permission { Name = "dashboard.view", DisplayName = "عرض لوحة التحكم", Category = "لوحة التحكم" },
                 new Permission { Name = "dashboard.widget.stats", DisplayName = "عرض لوحة التحكم stats", Category = "لوحة التحكم" },
                 new Permission { Name = "dashboard.widget.accounts", DisplayName = " accountsعرض لوحة التحكم", Category = "لوحة التحكم" },

--- a/AccountingSystem/Migrations/20250910120000_AddPivotReports.Designer.cs
+++ b/AccountingSystem/Migrations/20250910120000_AddPivotReports.Designer.cs
@@ -4,6 +4,7 @@ using AccountingSystem.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AccountingSystem.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250910120000_AddPivotReports")]
+    partial class AddPivotReports
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/AccountingSystem/Migrations/20250910120000_AddPivotReports.cs
+++ b/AccountingSystem/Migrations/20250910120000_AddPivotReports.cs
@@ -1,0 +1,70 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AccountingSystem.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPivotReports : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PivotReports",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(type: "nvarchar(150)", maxLength: 150, nullable: false),
+                    ReportType = table.Column<int>(type: "int", nullable: false),
+                    Layout = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    CreatedById = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime2", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PivotReports", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PivotReports_AspNetUsers_CreatedById",
+                        column: x => x.CreatedById,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PivotReports_CreatedById",
+                table: "PivotReports",
+                column: "CreatedById");
+
+            migrationBuilder.InsertData(
+                table: "Permissions",
+                columns: new[] { "Id", "Category", "CreatedAt", "Description", "DisplayName", "IsActive", "Name" },
+                values: new object[,]
+                {
+                    { 54, "التقارير", new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc), null, "عرض الحركات غير المرحلة", true, "reports.pending" },
+                    { 55, "التقارير", new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc), null, "التقارير التفاعلية", true, "reports.dynamic" }
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "Permissions",
+                keyColumn: "Id",
+                keyValue: 54);
+
+            migrationBuilder.DeleteData(
+                table: "Permissions",
+                keyColumn: "Id",
+                keyValue: 55);
+
+            migrationBuilder.DropTable(
+                name: "PivotReports");
+        }
+    }
+}

--- a/AccountingSystem/Models/DynamicReportType.cs
+++ b/AccountingSystem/Models/DynamicReportType.cs
@@ -1,0 +1,10 @@
+namespace AccountingSystem.Models
+{
+    public enum DynamicReportType
+    {
+        JournalEntries = 1,
+        ReceiptVouchers = 2,
+        PaymentVouchers = 3,
+        DisbursementVouchers = 4
+    }
+}

--- a/AccountingSystem/Models/PivotReport.cs
+++ b/AccountingSystem/Models/PivotReport.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace AccountingSystem.Models
+{
+    public class PivotReport
+    {
+        public int Id { get; set; }
+
+        [Required]
+        [StringLength(150)]
+        public string Name { get; set; } = string.Empty;
+
+        [Required]
+        public DynamicReportType ReportType { get; set; }
+
+        [Required]
+        public string Layout { get; set; } = string.Empty;
+
+        [Required]
+        public string CreatedById { get; set; } = string.Empty;
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+        public DateTime? UpdatedAt { get; set; }
+
+        public virtual User CreatedBy { get; set; } = null!;
+    }
+}

--- a/AccountingSystem/ViewModels/DynamicPivotReportViewModel.cs
+++ b/AccountingSystem/ViewModels/DynamicPivotReportViewModel.cs
@@ -1,0 +1,32 @@
+using System;
+using AccountingSystem.Models;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace AccountingSystem.ViewModels
+{
+    public class DynamicPivotReportViewModel
+    {
+        public List<SelectListItem> ReportTypes { get; set; } = new();
+    }
+
+    public class PivotReportListItemViewModel
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public DynamicReportType ReportType { get; set; }
+        public DateTime UpdatedAt { get; set; }
+    }
+
+    public class SavePivotReportRequest
+    {
+        public int? Id { get; set; }
+        public DynamicReportType ReportType { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Layout { get; set; } = string.Empty;
+    }
+
+    public class DeletePivotReportRequest
+    {
+        public int Id { get; set; }
+    }
+}

--- a/AccountingSystem/Views/Reports/DynamicPivot.cshtml
+++ b/AccountingSystem/Views/Reports/DynamicPivot.cshtml
@@ -1,0 +1,406 @@
+@model AccountingSystem.ViewModels.DynamicPivotReportViewModel
+@{
+    ViewData["Title"] = "التقارير التفاعلية";
+    Layout = "~/Views/Shared/_AccountingLayout.cshtml";
+    var today = DateTime.Today;
+    var defaultFrom = today.AddMonths(-1);
+}
+
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">
+            <div class="card mb-3">
+                <div class="card-header d-flex flex-wrap align-items-center justify-content-between">
+                    <h3 class="card-title mb-0">
+                        <i class="fas fa-table me-2"></i>
+                        التقارير التفاعلية
+                    </h3>
+                    <div class="text-muted small">
+                        قم باختيار نوع التقرير والفترة الزمنية ثم صمّم تقريرك باستخدام Pivot Table واحفظه للاستخدام لاحقاً.
+                    </div>
+                </div>
+                <div class="card-body">
+                    <div id="pivotMessages"></div>
+                    <div class="row g-3 align-items-end">
+                        <div class="col-md-3">
+                            <label for="reportType" class="form-label">نوع التقرير</label>
+                            <select id="reportType" class="form-select">
+                                @foreach (var type in Model.ReportTypes)
+                                {
+                                    <option value="@type.Value">@type.Text</option>
+                                }
+                            </select>
+                        </div>
+                        <div class="col-md-3">
+                            <label for="fromDate" class="form-label">من تاريخ</label>
+                            <input type="date" id="fromDate" class="form-control" value="@defaultFrom.ToString("yyyy-MM-dd")" />
+                        </div>
+                        <div class="col-md-3">
+                            <label for="toDate" class="form-label">إلى تاريخ</label>
+                            <input type="date" id="toDate" class="form-control" value="@today.ToString("yyyy-MM-dd")" />
+                        </div>
+                        <div class="col-md-3">
+                            <button id="loadDataBtn" class="btn btn-primary w-100">
+                                <i class="fas fa-sync-alt me-1"></i>
+                                تحميل البيانات
+                            </button>
+                        </div>
+                    </div>
+                    <div class="row g-3 align-items-end mt-3">
+                        <div class="col-md-6">
+                            <label for="savedReports" class="form-label">التقارير المحفوظة</label>
+                            <select id="savedReports" class="form-select">
+                                <option value="">-- اختر تقريراً محفوظاً --</option>
+                            </select>
+                        </div>
+                        <div class="col-md-6 text-md-end">
+                            <button id="saveReportBtn" class="btn btn-success me-2">
+                                <i class="fas fa-save me-1"></i>
+                                حفظ التقرير
+                            </button>
+                            <button id="saveAsReportBtn" class="btn btn-outline-primary me-2">
+                                <i class="fas fa-copy me-1"></i>
+                                حفظ كـ...
+                            </button>
+                            <button id="deleteReportBtn" class="btn btn-outline-danger">
+                                <i class="fas fa-trash me-1"></i>
+                                حذف التقرير
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="card">
+                <div class="card-body">
+                    @Html.AntiForgeryToken()
+                    <div id="dynamicPivot"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script>
+        (function () {
+            const reportTypeSelect = document.getElementById('reportType');
+            const savedReportsSelect = document.getElementById('savedReports');
+            const fromDateInput = document.getElementById('fromDate');
+            const toDateInput = document.getElementById('toDate');
+            const loadDataBtn = document.getElementById('loadDataBtn');
+            const saveReportBtn = document.getElementById('saveReportBtn');
+            const saveAsReportBtn = document.getElementById('saveAsReportBtn');
+            const deleteReportBtn = document.getElementById('deleteReportBtn');
+            const messagesContainer = document.getElementById('pivotMessages');
+            const antiForgeryToken = document.querySelector('input[name="__RequestVerificationToken"]').value;
+
+            let pivotObj = null;
+            let currentData = [];
+            let currentReportId = null;
+            let currentLayout = null;
+            let isLoadingSavedLayout = false;
+
+            function showMessage(type, text) {
+                messagesContainer.innerHTML = '';
+                if (!text) {
+                    return;
+                }
+                const alert = document.createElement('div');
+                alert.className = `alert alert-${type} alert-dismissible fade show`;
+                alert.setAttribute('role', 'alert');
+                alert.textContent = text;
+                const button = document.createElement('button');
+                button.type = 'button';
+                button.className = 'btn-close';
+                button.setAttribute('data-bs-dismiss', 'alert');
+                button.setAttribute('aria-label', 'Close');
+                alert.appendChild(button);
+                messagesContainer.appendChild(alert);
+            }
+
+            function getDefaultDataSourceSettings(data) {
+                return {
+                    dataSource: data,
+                    expandAll: false,
+                    enableSorting: true,
+                    rows: [],
+                    columns: [],
+                    values: [],
+                    filters: [],
+                    formatSettings: [
+                        { name: 'Debit', format: 'N2' },
+                        { name: 'Credit', format: 'N2' },
+                        { name: 'Amount', format: 'N2' },
+                        { name: 'AmountBase', format: 'N2' },
+                        { name: 'ExchangeRate', format: 'N4' }
+                    ]
+                };
+            }
+
+            function initializePivot() {
+                pivotObj = new ej.pivotview.PivotView({
+                    height: 600,
+                    locale: 'ar',
+                    enableRtl: true,
+                    showFieldList: true,
+                    showToolbar: true,
+                    toolbar: ['Grid', 'Chart', 'Export', 'SubTotal', 'GrandTotal', 'FieldList'],
+                    dataSourceSettings: getDefaultDataSourceSettings([]),
+                    gridSettings: {
+                        columnWidth: 140
+                    }
+                });
+                pivotObj.appendTo('#dynamicPivot');
+            }
+
+            async function loadSavedReports(reportType, preserveState = false) {
+                savedReportsSelect.innerHTML = '<option value="">-- اختر تقريراً محفوظاً --</option>';
+                if (!preserveState) {
+                    currentReportId = null;
+                    currentLayout = null;
+                }
+
+                try {
+                    const response = await fetch(`@Url.Action("GetPivotReports")?reportType=${reportType}`);
+                    if (!response.ok) {
+                        throw new Error('تعذر تحميل التقارير المحفوظة');
+                    }
+                    const reports = await response.json();
+                    reports.forEach(report => {
+                        const option = document.createElement('option');
+                        option.value = report.Id;
+                        option.textContent = `${report.Name}`;
+                        savedReportsSelect.appendChild(option);
+                    });
+                } catch (error) {
+                    showMessage('danger', error.message);
+                }
+            }
+
+            function applyLayout(layout) {
+                if (!pivotObj) {
+                    return;
+                }
+
+                if (!layout) {
+                    pivotObj.setProperties({ dataSourceSettings: getDefaultDataSourceSettings(currentData) });
+                    pivotObj.refreshData();
+                    return;
+                }
+
+                try {
+                    const parsed = JSON.parse(layout);
+                    pivotObj.setProperties(parsed);
+                } catch (error) {
+                    console.error('Failed to parse layout', error);
+                }
+
+                if (pivotObj.dataSourceSettings) {
+                    pivotObj.dataSourceSettings.dataSource = currentData;
+                } else {
+                    pivotObj.setProperties({ dataSourceSettings: getDefaultDataSourceSettings(currentData) });
+                }
+
+                pivotObj.refreshData();
+            }
+
+            async function loadReportLayout(reportId) {
+                if (!reportId) {
+                    currentLayout = null;
+                    return;
+                }
+                try {
+                    const response = await fetch(`@Url.Action("GetPivotReport")?id=${reportId}`);
+                    if (!response.ok) {
+                        throw new Error('تعذر تحميل إعدادات التقرير');
+                    }
+                    const report = await response.json();
+                    currentLayout = report.Layout;
+                    currentReportId = report.Id;
+                    const reportTypeValue = report.ReportType;
+                    isLoadingSavedLayout = true;
+                    if (reportTypeSelect.value !== reportTypeValue) {
+                        reportTypeSelect.value = reportTypeValue;
+                        await loadSavedReports(reportTypeValue, true);
+                        savedReportsSelect.value = report.Id.toString();
+                    }
+                    if (currentData.length > 0) {
+                        applyLayout(currentLayout);
+                    }
+                } catch (error) {
+                    showMessage('danger', error.message);
+                }
+            }
+
+            async function loadReportData() {
+                const reportType = reportTypeSelect.value;
+                const fromDate = fromDateInput.value;
+                const toDate = toDateInput.value;
+
+                const params = new URLSearchParams({
+                    reportType,
+                    fromDate,
+                    toDate
+                });
+
+                try {
+                    showMessage(null, null);
+                    if (!isLoadingSavedLayout && pivotObj) {
+                        currentLayout = pivotObj.getPersistData();
+                    }
+                    const response = await fetch(`@Url.Action("GetDynamicPivotData")?${params.toString()}`);
+                    if (!response.ok) {
+                        throw new Error('تعذر تحميل البيانات');
+                    }
+                    currentData = await response.json();
+                    if (!currentLayout) {
+                        pivotObj.setProperties({ dataSourceSettings: getDefaultDataSourceSettings(currentData) });
+                        pivotObj.refreshData();
+                    } else {
+                        applyLayout(currentLayout);
+                    }
+                    if (!currentReportId) {
+                        savedReportsSelect.value = '';
+                    }
+                    isLoadingSavedLayout = false;
+                    showMessage('success', 'تم تحديث البيانات بنجاح');
+                } catch (error) {
+                    showMessage('danger', error.message);
+                    isLoadingSavedLayout = false;
+                }
+            }
+
+            async function saveReport(isSaveAs) {
+                if (!pivotObj) {
+                    return;
+                }
+
+                const currentNameOption = savedReportsSelect.selectedOptions.length > 0 ? savedReportsSelect.selectedOptions[0].textContent : '';
+                const defaultName = isSaveAs ? '' : currentNameOption;
+                const name = prompt('أدخل اسم التقرير', defaultName || '');
+                if (!name) {
+                    return;
+                }
+
+                const payload = {
+                    id: !isSaveAs ? currentReportId : null,
+                    reportType: reportTypeSelect.value,
+                    name: name.trim(),
+                    layout: pivotObj.getPersistData()
+                };
+
+                try {
+                    const response = await fetch('@Url.Action("SavePivotReport")', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'RequestVerificationToken': antiForgeryToken
+                        },
+                        body: JSON.stringify(payload)
+                    });
+
+                    if (!response.ok) {
+                        const error = await response.json().catch(() => ({ message: 'تعذر حفظ التقرير' }));
+                        throw new Error(error.message || 'تعذر حفظ التقرير');
+                    }
+
+                    const result = await response.json();
+                    currentReportId = result.Id;
+                    currentLayout = payload.layout;
+                    await loadSavedReports(reportTypeSelect.value, true);
+                    savedReportsSelect.value = currentReportId ? currentReportId.toString() : '';
+                    showMessage('success', 'تم حفظ التقرير بنجاح');
+                } catch (error) {
+                    showMessage('danger', error.message);
+                }
+            }
+
+            async function deleteReport() {
+                if (!currentReportId) {
+                    showMessage('warning', 'الرجاء اختيار تقرير محفوظ لحذفه');
+                    return;
+                }
+
+                if (!confirm('هل أنت متأكد من حذف التقرير المحدد؟')) {
+                    return;
+                }
+
+                try {
+                    const response = await fetch('@Url.Action("DeletePivotReport")', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'RequestVerificationToken': antiForgeryToken
+                        },
+                        body: JSON.stringify({ id: currentReportId })
+                    });
+
+                    if (!response.ok) {
+                        const error = await response.json().catch(() => ({ message: 'تعذر حذف التقرير' }));
+                        throw new Error(error.message || 'تعذر حذف التقرير');
+                    }
+
+                    currentReportId = null;
+                    currentLayout = null;
+                    savedReportsSelect.value = '';
+                    await loadSavedReports(reportTypeSelect.value);
+                    showMessage('success', 'تم حذف التقرير بنجاح');
+                } catch (error) {
+                    showMessage('danger', error.message);
+                }
+            }
+
+            reportTypeSelect.addEventListener('change', async () => {
+                await loadSavedReports(reportTypeSelect.value);
+                currentData = [];
+                pivotObj.setProperties({ dataSourceSettings: getDefaultDataSourceSettings([]) });
+                pivotObj.refreshData();
+                isLoadingSavedLayout = false;
+            });
+
+            savedReportsSelect.addEventListener('change', async () => {
+                const selectedId = parseInt(savedReportsSelect.value, 10);
+                if (!selectedId) {
+                    currentReportId = null;
+                    currentLayout = null;
+                    return;
+                }
+                await loadReportLayout(selectedId);
+                await loadReportData();
+            });
+
+            loadDataBtn.addEventListener('click', async (e) => {
+                e.preventDefault();
+                await loadReportData();
+            });
+
+            saveReportBtn.addEventListener('click', async (e) => {
+                e.preventDefault();
+                await saveReport(false);
+            });
+
+            saveAsReportBtn.addEventListener('click', async (e) => {
+                e.preventDefault();
+                await saveReport(true);
+            });
+
+            deleteReportBtn.addEventListener('click', async (e) => {
+                e.preventDefault();
+                await deleteReport();
+            });
+
+            async function init() {
+                initializePivot();
+                await loadSavedReports(reportTypeSelect.value);
+                await loadReportData();
+            }
+
+            if (document.readyState === 'loading') {
+                document.addEventListener('DOMContentLoaded', init);
+            } else {
+                init();
+            }
+        })();
+    </script>
+}

--- a/AccountingSystem/Views/Reports/Index.cshtml
+++ b/AccountingSystem/Views/Reports/Index.cshtml
@@ -95,6 +95,19 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="col-md-4 mb-3">
+                            <div class="card h-100 border-primary">
+                                <div class="card-body text-center">
+                                    <i class="fas fa-table fa-3x text-primary mb-3"></i>
+                                    <h5 class="card-title">التقارير التفاعلية</h5>
+                                    <p class="card-text">أنشئ تقارير Pivot مخصصة واحفظها للاستخدام لاحقاً</p>
+                                    <a asp-action="DynamicPivot" class="btn btn-primary">
+                                        <i class="fas fa-magic me-1"></i>
+                                        إنشاء تقرير تفاعلي
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add a Syncfusion PivotView workspace for building and saving dynamic reports
- persist user-defined report layouts with a new PivotReport entity and migration
- seed the dynamic reporting permission and expose the feature from the reports hub

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d71b3f88bc8333a6289a67d17fcda0