### PR TITLE
Populate home dashboard charts with live data

### DIFF
--- a/AccountingSystem/Controllers/HomeController.cs
+++ b/AccountingSystem/Controllers/HomeController.cs
@@ -1,21 +1,212 @@
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using AccountingSystem.Data;
 using AccountingSystem.Models;
+using AccountingSystem.ViewModels;
 
 namespace AccountingSystem.Controllers;
 
 public class HomeController : Controller
 {
     private readonly ILogger<HomeController> _logger;
+    private readonly ApplicationDbContext _context;
 
-    public HomeController(ILogger<HomeController> logger)
+    public HomeController(ILogger<HomeController> logger, ApplicationDbContext context)
     {
         _logger = logger;
+        _context = context;
     }
 
-    public IActionResult Index()
+    public async Task<IActionResult> Index(DateTime? fromDate = null, DateTime? toDate = null)
     {
-        return View();
+        var startDate = fromDate?.Date ?? new DateTime(DateTime.Today.Year, DateTime.Today.Month, 1).AddMonths(-5);
+        var endDate = toDate?.Date ?? DateTime.Today;
+
+        if (endDate < startDate)
+        {
+            (startDate, endDate) = (endDate, startDate);
+        }
+
+        var monthStart = new DateTime(startDate.Year, startDate.Month, 1);
+        var monthEnd = new DateTime(endDate.Year, endDate.Month, 1);
+        var months = new List<DateTime>();
+        for (var month = monthStart; month <= monthEnd; month = month.AddMonths(1))
+        {
+            months.Add(month);
+        }
+
+        if (!months.Any())
+        {
+            months.Add(monthStart);
+        }
+
+        var lineData = await _context.JournalEntryLines
+            .Where(l => l.JournalEntry.Date >= startDate && l.JournalEntry.Date <= endDate)
+            .Select(l => new
+            {
+                l.JournalEntryId,
+                l.JournalEntry.Date,
+                Year = l.JournalEntry.Date.Year,
+                Month = l.JournalEntry.Date.Month,
+                BranchName = l.JournalEntry.Branch.NameAr,
+                l.Account.AccountType,
+                AccountName = l.Account.NameAr,
+                Debit = l.DebitAmount,
+                Credit = l.CreditAmount
+            })
+            .ToListAsync();
+
+        var monthlyFinancials = months.Select(month =>
+        {
+            var monthData = lineData.Where(x => x.Year == month.Year && x.Month == month.Month).ToList();
+            var revenue = monthData.Where(x => x.AccountType == AccountType.Revenue).Sum(x => x.Credit - x.Debit);
+            var expenses = monthData.Where(x => x.AccountType == AccountType.Expenses).Sum(x => x.Debit - x.Credit);
+            var profit = revenue - expenses;
+            return new MonthlyFinancialData
+            {
+                Month = month.ToString("yyyy MMM", CultureInfo.GetCultureInfo("ar-SA")),
+                Revenue = Math.Round(revenue, 2, MidpointRounding.AwayFromZero),
+                Expenses = Math.Round(expenses, 2, MidpointRounding.AwayFromZero),
+                Profit = Math.Round(profit, 2, MidpointRounding.AwayFromZero)
+            };
+        }).ToList();
+
+        var branchGroups = lineData
+            .GroupBy(x => string.IsNullOrWhiteSpace(x.BranchName) ? "غير محدد" : x.BranchName)
+            .Select(g => new
+            {
+                Branch = g.Key,
+                Revenue = g.Where(x => x.AccountType == AccountType.Revenue).Sum(x => x.Credit - x.Debit),
+                Expenses = g.Where(x => x.AccountType == AccountType.Expenses).Sum(x => x.Debit - x.Credit),
+                Entries = g.Select(x => x.JournalEntryId).Distinct().Count()
+            })
+            .OrderByDescending(g => g.Revenue - g.Expenses)
+            .ToList();
+
+        var departmentPerformance = branchGroups
+            .Select(g => new BranchPerformanceData
+            {
+                Department = g.Branch,
+                Score = Math.Round(g.Revenue - g.Expenses, 2, MidpointRounding.AwayFromZero)
+            })
+            .ToList();
+
+        var totalRevenue = branchGroups.Sum(g => g.Revenue);
+        var totalExpenses = branchGroups.Sum(g => g.Expenses);
+        var netIncome = totalRevenue - totalExpenses;
+
+        var marketShare = totalRevenue > 0
+            ? branchGroups.Select(g => new MarketShareData
+            {
+                Company = g.Branch,
+                Share = Math.Round((g.Revenue / totalRevenue) * 100m, 2, MidpointRounding.AwayFromZero)
+            }).ToList()
+            : new List<MarketShareData>();
+
+        var revenueAccounts = lineData
+            .Where(x => x.AccountType == AccountType.Revenue)
+            .GroupBy(x => string.IsNullOrWhiteSpace(x.AccountName) ? "غير مسمى" : x.AccountName)
+            .Select(g => new
+            {
+                Account = g.Key,
+                Amount = g.Sum(x => x.Credit - x.Debit)
+            })
+            .Where(g => g.Amount != 0)
+            .OrderByDescending(g => g.Amount)
+            .ToList();
+
+        var incomeSources = revenueAccounts
+            .Take(5)
+            .Select(g => new IncomeSourceData
+            {
+                Source = g.Account,
+                Value = Math.Round(g.Amount, 2, MidpointRounding.AwayFromZero)
+            })
+            .ToList();
+
+        var otherRevenue = revenueAccounts.Skip(5).Sum(g => g.Amount);
+        if (otherRevenue > 0)
+        {
+            incomeSources.Add(new IncomeSourceData
+            {
+                Source = "أخرى",
+                Value = Math.Round(otherRevenue, 2, MidpointRounding.AwayFromZero)
+            });
+        }
+
+        var receiptVouchers = await _context.ReceiptVouchers
+            .Where(v => v.Date >= startDate && v.Date <= endDate)
+            .Select(v => new SalesScatterPoint
+            {
+                Price = Math.Round(v.Amount, 2, MidpointRounding.AwayFromZero),
+                Units = Math.Round(v.ExchangeRate, 4, MidpointRounding.AwayFromZero)
+            })
+            .ToListAsync();
+
+        var maxEntries = branchGroups.Any() ? branchGroups.Max(g => g.Entries) : 1;
+        var riskReturn = branchGroups
+            .Select(g => new RiskReturnPoint
+            {
+                Sector = g.Branch,
+                Risk = Math.Round(g.Expenses, 2, MidpointRounding.AwayFromZero),
+                Return = Math.Round(g.Revenue, 2, MidpointRounding.AwayFromZero),
+                Size = Math.Round(maxEntries == 0 ? 1 : (decimal)g.Entries / maxEntries * 1.5m + 0.5m, 2, MidpointRounding.AwayFromZero)
+            })
+            .ToList();
+
+        var totalJournalEntries = await _context.JournalEntries
+            .Where(e => e.Date >= startDate && e.Date <= endDate)
+            .CountAsync();
+
+        var approvedJournalEntries = await _context.JournalEntries
+            .Where(e => e.Date >= startDate && e.Date <= endDate && e.Status == JournalEntryStatus.Approved)
+            .CountAsync();
+
+        var newAccounts = await _context.Accounts
+            .Where(a => a.CreatedAt >= startDate && a.CreatedAt <= endDate)
+            .CountAsync();
+
+        decimal ClampScore(decimal value)
+        {
+            if (value < 0m)
+            {
+                return 0m;
+            }
+
+            return value > 5m ? 5m : Math.Round(value, 2, MidpointRounding.AwayFromZero);
+        }
+
+        var financialScore = totalRevenue == 0 ? 0m : ClampScore((netIncome / totalRevenue) * 5m);
+        var customerScore = ClampScore(receiptVouchers.Count / 3m);
+        var processScore = totalJournalEntries == 0 ? 0m : ClampScore((decimal)approvedJournalEntries / totalJournalEntries * 5m);
+        var learningScore = ClampScore(newAccounts / 2m);
+
+        var balancedScorecard = new List<BalancedScorecardMetric>
+        {
+            new BalancedScorecardMetric { Dimension = "المالية", Score = financialScore },
+            new BalancedScorecardMetric { Dimension = "العملاء", Score = customerScore },
+            new BalancedScorecardMetric { Dimension = "العمليات الداخلية", Score = processScore },
+            new BalancedScorecardMetric { Dimension = "التعلم والنمو", Score = learningScore }
+        };
+
+        var viewModel = new HomeDashboardViewModel
+        {
+            FromDate = startDate,
+            ToDate = endDate,
+            MonthlyFinancials = monthlyFinancials,
+            DepartmentPerformance = departmentPerformance,
+            MarketShare = marketShare,
+            IncomeSources = incomeSources,
+            SalesScatter = receiptVouchers,
+            RiskReturn = riskReturn,
+            BalancedScorecard = balancedScorecard
+        };
+
+        return View(viewModel);
     }
 
     public IActionResult Privacy()

--- a/AccountingSystem/ViewModels/HomeDashboardViewModel.cs
+++ b/AccountingSystem/ViewModels/HomeDashboardViewModel.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+
+namespace AccountingSystem.ViewModels
+{
+    public class MonthlyFinancialData
+    {
+        public string Month { get; set; } = string.Empty;
+        public decimal Revenue { get; set; }
+        public decimal Expenses { get; set; }
+        public decimal Profit { get; set; }
+    }
+
+    public class BranchPerformanceData
+    {
+        public string Department { get; set; } = string.Empty;
+        public decimal Score { get; set; }
+    }
+
+    public class MarketShareData
+    {
+        public string Company { get; set; } = string.Empty;
+        public decimal Share { get; set; }
+    }
+
+    public class IncomeSourceData
+    {
+        public string Source { get; set; } = string.Empty;
+        public decimal Value { get; set; }
+    }
+
+    public class SalesScatterPoint
+    {
+        public decimal Price { get; set; }
+        public decimal Units { get; set; }
+    }
+
+    public class RiskReturnPoint
+    {
+        public string Sector { get; set; } = string.Empty;
+        public decimal Risk { get; set; }
+        public decimal Return { get; set; }
+        public decimal Size { get; set; }
+    }
+
+    public class BalancedScorecardMetric
+    {
+        public string Dimension { get; set; } = string.Empty;
+        public decimal Score { get; set; }
+    }
+
+    public class HomeDashboardViewModel
+    {
+        public DateTime FromDate { get; set; }
+        public DateTime ToDate { get; set; }
+        public List<MonthlyFinancialData> MonthlyFinancials { get; set; } = new();
+        public List<BranchPerformanceData> DepartmentPerformance { get; set; } = new();
+        public List<MarketShareData> MarketShare { get; set; } = new();
+        public List<IncomeSourceData> IncomeSources { get; set; } = new();
+        public List<SalesScatterPoint> SalesScatter { get; set; } = new();
+        public List<RiskReturnPoint> RiskReturn { get; set; } = new();
+        public List<BalancedScorecardMetric> BalancedScorecard { get; set; } = new();
+    }
+}

--- a/AccountingSystem/Views/Home/Index.cshtml
+++ b/AccountingSystem/Views/Home/Index.cshtml
@@ -1,10 +1,38 @@
-﻿@{
+@model AccountingSystem.ViewModels.HomeDashboardViewModel
+@using System.Text.Json
+@{
     ViewData["Title"] = "Home Page";
+    var jsonOptions = new JsonSerializerOptions
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
 }
 
 <div class="container py-4">
     <h1 class="mb-4 text-center">لوحة مؤشرات النظام</h1>
-    <p class="text-muted text-center mb-5">استعرض أداء النظام من خلال مجموعة متنوعة من الرسوم البيانية التفاعلية من Syncfusion، مع إمكانية إخفاء أي منها مع تذكر حالتها تلقائياً.</p>
+    <p class="text-muted text-center mb-4">استعرض أداء النظام باستخدام بيانات فعلية ضمن الفترة المحددة، مع إمكانية إخفاء أي رسم بياني مع تذكر حالته تلقائياً.</p>
+
+    <form method="get" class="row g-3 justify-content-center mb-4 align-items-end">
+        <div class="col-md-3">
+            <label for="fromDate" class="form-label">من تاريخ</label>
+            <input type="date" class="form-control" id="fromDate" name="fromDate" value="@Model.FromDate.ToString("yyyy-MM-dd")" />
+        </div>
+        <div class="col-md-3">
+            <label for="toDate" class="form-label">إلى تاريخ</label>
+            <input type="date" class="form-control" id="toDate" name="toDate" value="@Model.ToDate.ToString("yyyy-MM-dd")" />
+        </div>
+        <div class="col-md-2 d-grid">
+            <button type="submit" class="btn btn-primary">تحديث البيانات</button>
+        </div>
+    </form>
+
+    <div class="alert alert-info text-center mb-4" role="status">
+        البيانات المعروضة للفترة من
+        <strong>@Model.FromDate.ToString("yyyy/MM/dd")</strong>
+        إلى
+        <strong>@Model.ToDate.ToString("yyyy/MM/dd")</strong>
+    </div>
 
     <div class="row g-4">
         <div class="col-12">
@@ -94,7 +122,7 @@
         <div class="col-12">
             <div class="card chart-card" data-collapse-id="scatter-chart">
                 <div class="card-header d-flex justify-content-between align-items-center">
-                    <h5 class="mb-0">تحليل المبيعات حسب السعر - مخطط مبعثر</h5>
+                    <h5 class="mb-0">تحليل سندات القبض - مخطط مبعثر</h5>
                     <button class="btn btn-sm btn-outline-primary" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-scatter-chart" aria-expanded="true" aria-controls="collapse-scatter-chart">إظهار / إخفاء</button>
                 </div>
                 <div id="collapse-scatter-chart" class="collapse show">
@@ -186,70 +214,23 @@
                 });
             });
 
-            // إعداد البيانات المشتركة للرسوم البيانية
-            var monthlyFinancials = [
-                { month: 'Jan', revenue: 35, profit: 20, expenses: 15 },
-                { month: 'Feb', revenue: 42, profit: 25, expenses: 18 },
-                { month: 'Mar', revenue: 51, profit: 28, expenses: 23 },
-                { month: 'Apr', revenue: 58, profit: 32, expenses: 26 },
-                { month: 'May', revenue: 64, profit: 36, expenses: 28 },
-                { month: 'Jun', revenue: 72, profit: 40, expenses: 32 },
-                { month: 'Jul', revenue: 78, profit: 44, expenses: 34 },
-                { month: 'Aug', revenue: 85, profit: 47, expenses: 38 },
-                { month: 'Sep', revenue: 90, profit: 50, expenses: 40 },
-                { month: 'Oct', revenue: 96, profit: 54, expenses: 42 },
-                { month: 'Nov', revenue: 102, profit: 57, expenses: 45 },
-                { month: 'Dec', revenue: 108, profit: 61, expenses: 47 }
-            ];
+            const monthlyFinancials = @Html.Raw(JsonSerializer.Serialize(Model.MonthlyFinancials, jsonOptions));
+            const departmentPerformance = @Html.Raw(JsonSerializer.Serialize(Model.DepartmentPerformance, jsonOptions));
+            const marketShare = @Html.Raw(JsonSerializer.Serialize(Model.MarketShare, jsonOptions));
+            const incomeSources = @Html.Raw(JsonSerializer.Serialize(Model.IncomeSources, jsonOptions));
+            const salesScatter = @Html.Raw(JsonSerializer.Serialize(Model.SalesScatter, jsonOptions));
+            const riskReturn = @Html.Raw(JsonSerializer.Serialize(Model.RiskReturn, jsonOptions));
+            const balancedScorecard = @Html.Raw(JsonSerializer.Serialize(Model.BalancedScorecard, jsonOptions));
 
-            var departmentPerformance = [
-                { department: 'المبيعات', score: 92 },
-                { department: 'التسويق', score: 78 },
-                { department: 'العمليات', score: 88 },
-                { department: 'المالية', score: 96 },
-                { department: 'الموارد البشرية', score: 82 }
-            ];
-
-            var marketShare = [
-                { company: 'الشركة A', share: 37 },
-                { company: 'الشركة B', share: 21 },
-                { company: 'الشركة C', share: 18 },
-                { company: 'الشركة D', share: 14 },
-                { company: 'أخرى', share: 10 }
-            ];
-
-            var incomeSources = [
-                { source: 'المنتجات', value: 52 },
-                { source: 'الخدمات', value: 26 },
-                { source: 'الاشتراكات', value: 14 },
-                { source: 'استثمارات', value: 8 }
-            ];
-
-            var salesScatter = [
-                { price: 15, units: 35 },
-                { price: 22, units: 28 },
-                { price: 28, units: 34 },
-                { price: 35, units: 26 },
-                { price: 42, units: 30 },
-                { price: 48, units: 22 },
-                { price: 54, units: 18 },
-                { price: 60, units: 16 }
-            ];
-
-            var riskReturn = [
-                { sector: 'تقنية', risk: 12, return: 22, size: 1.1 },
-                { sector: 'صناعة', risk: 18, return: 15, size: 0.9 },
-                { sector: 'مالية', risk: 10, return: 18, size: 1.3 },
-                { sector: 'صحة', risk: 8, return: 14, size: 0.7 },
-                { sector: 'طاقة', risk: 22, return: 20, size: 1.5 }
-            ];
-
-            var balancedScorecard = [
-                { dimension: 'المالية', score: 4.4 },
-                { dimension: 'العملاء', score: 3.8 },
-                { dimension: 'العمليات الداخلية', score: 4.1 },
-                { dimension: 'التعلم والنمو', score: 3.5 }
-            ];
+            const cashflowSeries = monthlyFinancials.map(function (item, index) {
+                const cumulative = monthlyFinancials
+                    .slice(0, index + 1)
+                    .reduce(function (sum, current) { return sum + (current.profit || 0); }, 0);
+                return {
+                    month: item.month,
+                    cumulative: cumulative
+                };
+            });
 
             ej.charts.Chart.Inject(
                 ej.charts.LineSeries,
@@ -277,7 +258,7 @@
 
             new ej.charts.Chart({
                 primaryXAxis: { valueType: 'Category' },
-                primaryYAxis: { labelFormat: '{value}K' },
+                primaryYAxis: { labelFormat: '{value:N0}' },
                 title: 'نمو الإيرادات الشهرية',
                 tooltip: { enable: true },
                 series: [{
@@ -292,7 +273,7 @@
 
             new ej.charts.Chart({
                 primaryXAxis: { valueType: 'Category' },
-                primaryYAxis: { labelFormat: '{value}K' },
+                primaryYAxis: { labelFormat: '{value:N0}' },
                 title: 'الأرباح مقابل الإيرادات',
                 tooltip: { enable: true },
                 legendSettings: { visible: true },
@@ -316,7 +297,7 @@
 
             new ej.charts.Chart({
                 primaryXAxis: { valueType: 'Category' },
-                primaryYAxis: { labelFormat: '{value}K' },
+                primaryYAxis: { labelFormat: '{value:N0}' },
                 title: 'النفقات المتراكمة',
                 tooltip: { enable: true },
                 series: [{
@@ -330,7 +311,7 @@
 
             new ej.charts.Chart({
                 primaryXAxis: { valueType: 'Category' },
-                primaryYAxis: { labelFormat: '{value}K' },
+                primaryYAxis: { labelFormat: '{value:N0}' },
                 title: 'صافي التدفق النقدي',
                 tooltip: { enable: true },
                 series: [
@@ -347,13 +328,20 @@
                         xName: 'month',
                         yName: 'expenses',
                         name: 'نفقات'
+                    },
+                    {
+                        type: 'SplineArea',
+                        dataSource: cashflowSeries,
+                        xName: 'month',
+                        yName: 'cumulative',
+                        name: 'التدفق التراكمي'
                     }
                 ]
             }, '#areaChart');
 
             new ej.charts.Chart({
                 primaryXAxis: { valueType: 'Category' },
-                primaryYAxis: { interval: 10, labelFormat: '{value}%' },
+                primaryYAxis: { labelFormat: '{value:N0}' },
                 title: 'مستوى الأداء حسب القسم',
                 tooltip: { enable: true },
                 series: [{
@@ -366,7 +354,7 @@
             }, '#barChart');
 
             new ej.charts.AccumulationChart({
-                title: 'الحصة السوقية للشركات',
+                title: 'الحصة السوقية حسب الفروع',
                 legendSettings: { visible: true },
                 tooltip: { enable: true },
                 series: [{
@@ -392,9 +380,9 @@
             }, '#doughnutChart');
 
             new ej.charts.Chart({
-                primaryXAxis: { title: 'السعر (بالدولار)' },
-                primaryYAxis: { title: 'الوحدات المباعة (بالألف)' },
-                title: 'العلاقة بين السعر وحجم المبيعات',
+                primaryXAxis: { title: 'المبلغ' },
+                primaryYAxis: { title: 'معامل التحويل' },
+                title: 'العلاقة بين قيمة سندات القبض ومعامل التحويل',
                 tooltip: { enable: true },
                 series: [{
                     type: 'Scatter',
@@ -406,9 +394,9 @@
             }, '#scatterChart');
 
             new ej.charts.Chart({
-                primaryXAxis: { title: 'المخاطر (%)' },
-                primaryYAxis: { title: 'العائد المتوقع (%)' },
-                title: 'المخاطر مقابل العائد حسب القطاع',
+                primaryXAxis: { title: 'إجمالي النفقات' },
+                primaryYAxis: { title: 'إجمالي الإيرادات' },
+                title: 'المخاطر مقابل العائد حسب الفروع',
                 tooltip: { enable: true },
                 series: [{
                     type: 'Bubble',
@@ -416,7 +404,7 @@
                     xName: 'risk',
                     yName: 'return',
                     size: 'size',
-                    name: 'القطاعات'
+                    name: 'الفروع'
                 }]
             }, '#bubbleChart');
 


### PR DESCRIPTION
## Summary
- add a dedicated home dashboard view model to carry chart datasets and selected dates
- aggregate journal entries, vouchers, and accounts in `HomeController` to feed real metrics for the selected period
- render the home dashboard view with a date range filter, live JSON data bindings, and refined chart configurations

## Testing
- dotnet build *(fails: `dotnet` not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d73395bed48333a2d77f6e0fd8fc84