### PR TITLE
Add Syncfusion query builder report designer

### DIFF
--- a/AccountingSystem/AccountingSystem.csproj
+++ b/AccountingSystem/AccountingSystem.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Syncfusion.EJ2.AspNet.Core" Version="31.1.21" />
     <PackageReference Include="Syncfusion.EJ2.PdfViewer.AspNet.Core" Version="31.1.21" />
     <PackageReference Include="Syncfusion.Pdf.Net.Core" Version="31.1.21" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.3.2" />
   </ItemGroup>
 
 

--- a/AccountingSystem/Data/ApplicationDbContext.cs
+++ b/AccountingSystem/Data/ApplicationDbContext.cs
@@ -45,6 +45,7 @@ namespace AccountingSystem.Data
         public DbSet<Asset> Assets { get; set; }
         public DbSet<AssetExpense> AssetExpenses { get; set; }
         public DbSet<PivotReport> PivotReports { get; set; }
+        public DbSet<ReportQuery> ReportQueries { get; set; }
 
         public override int SaveChanges()
         {
@@ -258,6 +259,23 @@ namespace AccountingSystem.Data
                     .WithMany()
                     .HasForeignKey(e => e.CreatedById)
                     .OnDelete(DeleteBehavior.Cascade);
+            });
+
+            builder.Entity<ReportQuery>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.Name).IsRequired().HasMaxLength(150);
+                entity.Property(e => e.Description).HasMaxLength(250);
+                entity.Property(e => e.DatasetKey).IsRequired().HasMaxLength(100);
+                entity.Property(e => e.RulesJson).IsRequired();
+                entity.Property(e => e.SelectedColumnsJson);
+                entity.Property(e => e.CreatedAt).HasColumnType("datetime2");
+                entity.Property(e => e.UpdatedAt).HasColumnType("datetime2");
+
+                entity.HasOne(e => e.CreatedBy)
+                    .WithMany()
+                    .HasForeignKey(e => e.CreatedById)
+                    .OnDelete(DeleteBehavior.Restrict);
             });
 
             // JournalEntry configuration

--- a/AccountingSystem/Migrations/20251015120000_AddReportQueries.Designer.cs
+++ b/AccountingSystem/Migrations/20251015120000_AddReportQueries.Designer.cs
@@ -4,6 +4,7 @@ using AccountingSystem.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AccountingSystem.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251015120000_AddReportQueries")]
+    partial class AddReportQueries
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/AccountingSystem/Migrations/20251015120000_AddReportQueries.cs
+++ b/AccountingSystem/Migrations/20251015120000_AddReportQueries.cs
@@ -1,0 +1,53 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AccountingSystem.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddReportQueries : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ReportQueries",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(type: "nvarchar(150)", maxLength: 150, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(250)", maxLength: 250, nullable: true),
+                    DatasetKey = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    RulesJson = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    SelectedColumnsJson = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedById = table.Column<string>(type: "nvarchar(450)", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime2", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ReportQueries", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ReportQueries_AspNetUsers_CreatedById",
+                        column: x => x.CreatedById,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReportQueries_CreatedById",
+                table: "ReportQueries",
+                column: "CreatedById");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ReportQueries");
+        }
+    }
+}

--- a/AccountingSystem/Models/ReportQuery.cs
+++ b/AccountingSystem/Models/ReportQuery.cs
@@ -1,0 +1,34 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace AccountingSystem.Models;
+
+public class ReportQuery
+{
+    public int Id { get; set; }
+
+    [Required]
+    [MaxLength(150)]
+    public string Name { get; set; } = string.Empty;
+
+    [MaxLength(250)]
+    public string? Description { get; set; }
+
+    [Required]
+    [MaxLength(100)]
+    public string DatasetKey { get; set; } = string.Empty;
+
+    [Required]
+    public string RulesJson { get; set; } = string.Empty;
+
+    public string? SelectedColumnsJson { get; set; }
+
+    public string? CreatedById { get; set; }
+
+    [ForeignKey(nameof(CreatedById))]
+    public User? CreatedBy { get; set; }
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    public DateTime? UpdatedAt { get; set; }
+}

--- a/AccountingSystem/Services/Reports/QueryBuilderDatasets.cs
+++ b/AccountingSystem/Services/Reports/QueryBuilderDatasets.cs
@@ -1,0 +1,221 @@
+using AccountingSystem.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace AccountingSystem.Services;
+
+public static class QueryBuilderDatasets
+{
+    public static IReadOnlyList<QueryDatasetDefinition> All { get; } = new List<QueryDatasetDefinition>
+    {
+        new(
+            "journalEntries",
+            "قيود اليومية",
+            "تحليل قيود اليومية مع تفاصيل الحسابات والفروع ومراكز التكلفة.",
+            new List<QueryDatasetField>
+            {
+                new("JournalEntryId", "معرّف القيد", QueryFieldType.Number, "القيد"),
+                new("EntryNumber", "رقم القيد", QueryFieldType.String, "القيد"),
+                new("EntryDate", "تاريخ القيد", QueryFieldType.Date, "القيد"),
+                new("EntryYear", "سنة القيد", QueryFieldType.Number, "القيد"),
+                new("EntryMonth", "شهر القيد", QueryFieldType.Number, "القيد"),
+                new("EntryStatus", "حالة القيد", QueryFieldType.String, "القيد"),
+                new("BranchCode", "كود الفرع", QueryFieldType.String, "الفرع"),
+                new("BranchName", "اسم الفرع", QueryFieldType.String, "الفرع"),
+                new("AccountCode", "كود الحساب", QueryFieldType.String, "الحساب"),
+                new("AccountName", "اسم الحساب", QueryFieldType.String, "الحساب"),
+                new("AccountBranch", "فرع الحساب", QueryFieldType.String, "الحساب"),
+                new("CostCenter", "مركز التكلفة", QueryFieldType.String, "مراكز التكلفة"),
+                new("LineDescription", "وصف السطر", QueryFieldType.String, "القيد"),
+                new("Reference", "المرجع", QueryFieldType.String, "القيد"),
+                new("Debit", "مدين", QueryFieldType.Decimal, "القيم"),
+                new("Credit", "دائن", QueryFieldType.Decimal, "القيم"),
+            },
+            context => context.JournalEntryLines
+                .AsNoTracking()
+                .Include(l => l.JournalEntry).ThenInclude(e => e.Branch)
+                .Include(l => l.Account).ThenInclude(a => a.Branch)
+                .Include(l => l.CostCenter)
+                .Select(l => new JournalEntryQueryRow
+                {
+                    JournalEntryId = l.JournalEntryId,
+                    EntryNumber = l.JournalEntry.Number,
+                    EntryDate = l.JournalEntry.Date,
+                    EntryYear = l.JournalEntry.Date.Year,
+                    EntryMonth = l.JournalEntry.Date.Month,
+                    EntryStatus = l.JournalEntry.Status.ToString(),
+                    BranchCode = l.JournalEntry.Branch != null ? l.JournalEntry.Branch.Code : null,
+                    BranchName = l.JournalEntry.Branch != null ? l.JournalEntry.Branch.NameAr : null,
+                    AccountCode = l.Account.Code,
+                    AccountName = l.Account.NameAr,
+                    AccountBranch = l.Account.Branch != null ? l.Account.Branch.NameAr : null,
+                    CostCenter = l.CostCenter != null ? l.CostCenter.NameAr : null,
+                    LineDescription = l.Description,
+                    Reference = l.Reference,
+                    Debit = l.DebitAmount,
+                    Credit = l.CreditAmount
+                })
+        ),
+        new(
+            "receiptVouchers",
+            "سندات القبض",
+            "عرض سندات القبض مع تفاصيل الحسابات والعملات والمستخدمين.",
+            new List<QueryDatasetField>
+            {
+                new("Id", "المعرف", QueryFieldType.Number, "السند"),
+                new("Date", "تاريخ السند", QueryFieldType.Date, "السند"),
+                new("Year", "السنة", QueryFieldType.Number, "السند"),
+                new("Month", "الشهر", QueryFieldType.Number, "السند"),
+                new("AccountCode", "كود الحساب", QueryFieldType.String, "الحساب"),
+                new("AccountName", "اسم الحساب", QueryFieldType.String, "الحساب"),
+                new("BranchCode", "كود الفرع", QueryFieldType.String, "الفرع"),
+                new("BranchName", "اسم الفرع", QueryFieldType.String, "الفرع"),
+                new("Currency", "العملة", QueryFieldType.String, "العملة"),
+                new("Amount", "المبلغ", QueryFieldType.Decimal, "القيم"),
+                new("ExchangeRate", "سعر الصرف", QueryFieldType.Decimal, "القيم"),
+                new("AmountBase", "المبلغ بالأساس", QueryFieldType.Decimal, "القيم"),
+                new("CreatedBy", "تم الإنشاء بواسطة", QueryFieldType.String, "السند"),
+                new("Notes", "ملاحظات", QueryFieldType.String, "السند"),
+            },
+            context => context.ReceiptVouchers
+                .AsNoTracking()
+                .Include(r => r.Account).ThenInclude(a => a.Branch)
+                .Include(r => r.Currency)
+                .Include(r => r.CreatedBy)
+                .Select(r => new VoucherQueryRow
+                {
+                    Id = r.Id,
+                    Date = r.Date,
+                    Year = r.Date.Year,
+                    Month = r.Date.Month,
+                    AccountCode = r.Account.Code,
+                    AccountName = r.Account.NameAr,
+                    BranchCode = r.Account.Branch != null ? r.Account.Branch.Code : null,
+                    BranchName = r.Account.Branch != null ? r.Account.Branch.NameAr : null,
+                    Currency = r.Currency.Code,
+                    Amount = r.Amount,
+                    ExchangeRate = r.ExchangeRate,
+                    AmountBase = r.Amount * r.ExchangeRate,
+                    CreatedBy = r.CreatedBy != null ? r.CreatedBy.UserName : null,
+                    Notes = r.Notes
+                })
+        ),
+        new(
+            "paymentVouchers",
+            "سندات الدفع",
+            "متابعة سندات الدفع مع بيانات المورد والحساب والعملة.",
+            new List<QueryDatasetField>
+            {
+                new("Id", "المعرف", QueryFieldType.Number, "السند"),
+                new("Date", "تاريخ السند", QueryFieldType.Date, "السند"),
+                new("Year", "السنة", QueryFieldType.Number, "السند"),
+                new("Month", "الشهر", QueryFieldType.Number, "السند"),
+                new("Supplier", "المورد", QueryFieldType.String, "المورد"),
+                new("AccountCode", "كود الحساب", QueryFieldType.String, "الحساب"),
+                new("AccountName", "اسم الحساب", QueryFieldType.String, "الحساب"),
+                new("BranchCode", "كود الفرع", QueryFieldType.String, "الفرع"),
+                new("BranchName", "اسم الفرع", QueryFieldType.String, "الفرع"),
+                new("Currency", "العملة", QueryFieldType.String, "العملة"),
+                new("Amount", "المبلغ", QueryFieldType.Decimal, "القيم"),
+                new("ExchangeRate", "سعر الصرف", QueryFieldType.Decimal, "القيم"),
+                new("AmountBase", "المبلغ بالأساس", QueryFieldType.Decimal, "القيم"),
+                new("CreatedBy", "تم الإنشاء بواسطة", QueryFieldType.String, "السند"),
+                new("IsCash", "نقدي؟", QueryFieldType.Boolean, "السند"),
+                new("Notes", "ملاحظات", QueryFieldType.String, "السند"),
+            },
+            context => context.PaymentVouchers
+                .AsNoTracking()
+                .Include(v => v.Supplier)
+                .Include(v => v.Account).ThenInclude(a => a!.Branch)
+                .Include(v => v.Currency)
+                .Include(v => v.CreatedBy)
+                .Select(v => new PaymentVoucherQueryRow
+                {
+                    Id = v.Id,
+                    Date = v.Date,
+                    Year = v.Date.Year,
+                    Month = v.Date.Month,
+                    Supplier = v.Supplier != null ? v.Supplier.NameAr : null,
+                    AccountCode = v.Account != null ? v.Account.Code : null,
+                    AccountName = v.Account != null ? v.Account.NameAr : null,
+                    BranchCode = v.Account != null && v.Account.Branch != null ? v.Account.Branch.Code : null,
+                    BranchName = v.Account != null && v.Account.Branch != null ? v.Account.Branch.NameAr : null,
+                    Currency = v.Currency.Code,
+                    Amount = v.Amount,
+                    ExchangeRate = v.ExchangeRate,
+                    AmountBase = v.Amount * v.ExchangeRate,
+                    CreatedBy = v.CreatedBy != null ? v.CreatedBy.UserName : null,
+                    IsCash = v.IsCash,
+                    Notes = v.Notes
+                })
+        )
+    };
+
+    public static QueryDatasetDefinition? GetByKey(string key) =>
+        All.FirstOrDefault(d => string.Equals(d.Key, key, StringComparison.OrdinalIgnoreCase));
+}
+
+public record QueryDatasetDefinition(
+    string Key,
+    string Name,
+    string Description,
+    IReadOnlyList<QueryDatasetField> Fields,
+    Func<ApplicationDbContext, IQueryable> QueryFactory);
+
+public record QueryDatasetField(
+    string Field,
+    string Label,
+    QueryFieldType FieldType,
+    string Category);
+
+public enum QueryFieldType
+{
+    String,
+    Number,
+    Decimal,
+    Date,
+    Boolean
+}
+
+public class JournalEntryQueryRow
+{
+    public int JournalEntryId { get; set; }
+    public string EntryNumber { get; set; } = string.Empty;
+    public DateTime EntryDate { get; set; }
+    public int EntryYear { get; set; }
+    public int EntryMonth { get; set; }
+    public string EntryStatus { get; set; } = string.Empty;
+    public string? BranchCode { get; set; }
+    public string? BranchName { get; set; }
+    public string AccountCode { get; set; } = string.Empty;
+    public string AccountName { get; set; } = string.Empty;
+    public string? AccountBranch { get; set; }
+    public string? CostCenter { get; set; }
+    public string? LineDescription { get; set; }
+    public string? Reference { get; set; }
+    public decimal Debit { get; set; }
+    public decimal Credit { get; set; }
+}
+
+public class VoucherQueryRow
+{
+    public int Id { get; set; }
+    public DateTime Date { get; set; }
+    public int Year { get; set; }
+    public int Month { get; set; }
+    public string AccountCode { get; set; } = string.Empty;
+    public string AccountName { get; set; } = string.Empty;
+    public string? BranchCode { get; set; }
+    public string? BranchName { get; set; }
+    public string Currency { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public decimal ExchangeRate { get; set; }
+    public decimal AmountBase { get; set; }
+    public string? CreatedBy { get; set; }
+    public string? Notes { get; set; }
+}
+
+public class PaymentVoucherQueryRow : VoucherQueryRow
+{
+    public string? Supplier { get; set; }
+    public bool IsCash { get; set; }
+}

--- a/AccountingSystem/ViewModels/QueryBuilderReportViewModel.cs
+++ b/AccountingSystem/ViewModels/QueryBuilderReportViewModel.cs
@@ -1,0 +1,61 @@
+using Microsoft.AspNetCore.Mvc.Rendering;
+using System.ComponentModel.DataAnnotations;
+
+namespace AccountingSystem.ViewModels;
+
+public class QueryBuilderReportViewModel
+{
+    public List<SelectListItem> Datasets { get; set; } = new();
+}
+
+public class QueryDatasetInfoViewModel
+{
+    public string Key { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public List<QueryDatasetFieldViewModel> Fields { get; set; } = new();
+}
+
+public class QueryDatasetFieldViewModel
+{
+    public string Field { get; set; } = string.Empty;
+    public string Label { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
+    public string Category { get; set; } = string.Empty;
+}
+
+public class ReportQueryListItemViewModel
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string DatasetKey { get; set; } = string.Empty;
+    public DateTime UpdatedAt { get; set; }
+}
+
+public class SaveReportQueryRequest
+{
+    [Required]
+    public string Name { get; set; } = string.Empty;
+
+    [Required]
+    public string DatasetKey { get; set; } = string.Empty;
+
+    [Required]
+    public string RulesJson { get; set; } = string.Empty;
+
+    public string? SelectedColumnsJson { get; set; }
+
+    public int? Id { get; set; }
+}
+
+public class DeleteReportQueryRequest
+{
+    public int Id { get; set; }
+}
+
+public class ExecuteReportQueryRequest
+{
+    public string DatasetKey { get; set; } = string.Empty;
+    public string? RulesJson { get; set; }
+    public List<string>? Columns { get; set; }
+}

--- a/AccountingSystem/Views/Reports/Index.cshtml
+++ b/AccountingSystem/Views/Reports/Index.cshtml
@@ -108,6 +108,19 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="col-md-4 mb-3">
+                            <div class="card h-100 border-info">
+                                <div class="card-body text-center">
+                                    <i class="fas fa-project-diagram fa-3x text-info mb-3"></i>
+                                    <h5 class="card-title">مصمم الاستعلامات</h5>
+                                    <p class="card-text">استخدم Query Builder لربط الجداول وحفظ الاستعلامات المخصصة</p>
+                                    <a asp-action="QueryBuilder" class="btn btn-info">
+                                        <i class="fas fa-filter me-1"></i>
+                                        إنشاء تقرير Query Builder
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/AccountingSystem/Views/Reports/QueryBuilder.cshtml
+++ b/AccountingSystem/Views/Reports/QueryBuilder.cshtml
@@ -1,0 +1,581 @@
+@model AccountingSystem.ViewModels.QueryBuilderReportViewModel
+@{
+    ViewData["Title"] = "مصمم التقارير";
+    Layout = "~/Views/Shared/_AccountingLayout.cshtml";
+}
+
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">
+            <div class="card mb-3">
+                <div class="card-header d-flex flex-wrap align-items-center justify-content-between">
+                    <h3 class="card-title mb-0">
+                        <i class="fas fa-filter me-2"></i>
+                        مصمم التقارير التفاعلي
+                    </h3>
+                    <div class="text-muted small">
+                        اختر مجموعة البيانات، أنشئ شروط التقرير باستخدام Query Builder، ثم احفظ الاستعلام لتنفيذه مرة أخرى.
+                    </div>
+                </div>
+                <div class="card-body">
+                    <div id="reportMessages"></div>
+                    <div class="row g-3 align-items-end">
+                        <div class="col-lg-4 col-md-6">
+                            <label for="datasetSelect" class="form-label">مجموعة البيانات</label>
+                            <select id="datasetSelect" class="form-select">
+                                <option value="">-- اختر مجموعة بيانات --</option>
+                                @foreach (var dataset in Model.Datasets)
+                                {
+                                    <option value="@dataset.Value">@dataset.Text</option>
+                                }
+                            </select>
+                        </div>
+                        <div class="col-lg-4 col-md-6">
+                            <label for="savedQueries" class="form-label">الاستعلامات المحفوظة</label>
+                            <select id="savedQueries" class="form-select">
+                                <option value="">-- اختر استعلاماً محفوظاً --</option>
+                            </select>
+                        </div>
+                        <div class="col-lg-4 col-md-6">
+                            <label for="queryName" class="form-label">اسم الاستعلام</label>
+                            <input id="queryName" type="text" class="form-control" placeholder="أدخل اسم الاستعلام" />
+                        </div>
+                        <div class="col-lg-4 col-md-6">
+                            <label class="form-label">الأعمدة المعروضة</label>
+                            <input type="text" id="columnsSelect" />
+                        </div>
+                        <div class="col-lg-8 col-md-12">
+                            <label class="form-label">وصف مجموعة البيانات</label>
+                            <div id="datasetDescription" class="alert alert-light border mb-0">اختر مجموعة البيانات لعرض التفاصيل.</div>
+                        </div>
+                    </div>
+                    <div class="mt-3 d-flex flex-wrap gap-2">
+                        <button id="runQueryBtn" class="btn btn-primary">
+                            <i class="fas fa-play me-1"></i>
+                            تنفيذ الاستعلام
+                        </button>
+                        <button id="saveQueryBtn" class="btn btn-success">
+                            <i class="fas fa-save me-1"></i>
+                            حفظ الاستعلام
+                        </button>
+                        <button id="saveAsQueryBtn" class="btn btn-outline-primary">
+                            <i class="fas fa-copy me-1"></i>
+                            حفظ كاستعلام جديد
+                        </button>
+                        <button id="deleteQueryBtn" class="btn btn-outline-danger">
+                            <i class="fas fa-trash me-1"></i>
+                            حذف الاستعلام
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <div class="card mb-3">
+                <div class="card-header">
+                    <h4 class="card-title mb-0">
+                        <i class="fas fa-sitemap me-2"></i>
+                        شروط التقرير
+                    </h4>
+                </div>
+                <div class="card-body">
+                    <div id="queryBuilder"></div>
+                </div>
+            </div>
+
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <h4 class="card-title mb-0">
+                        <i class="fas fa-table me-2"></i>
+                        النتائج
+                    </h4>
+                    <span class="text-muted small">سيتم عرض أول 5000 سجل فقط لاعتبارات الأداء.</span>
+                </div>
+                <div class="card-body">
+                    @Html.AntiForgeryToken()
+                    <div id="resultsGrid"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script>
+        (function () {
+            const datasetSelect = document.getElementById('datasetSelect');
+            const savedQueriesSelect = document.getElementById('savedQueries');
+            const queryNameInput = document.getElementById('queryName');
+            const datasetDescription = document.getElementById('datasetDescription');
+            const runQueryBtn = document.getElementById('runQueryBtn');
+            const saveQueryBtn = document.getElementById('saveQueryBtn');
+            const saveAsQueryBtn = document.getElementById('saveAsQueryBtn');
+            const deleteQueryBtn = document.getElementById('deleteQueryBtn');
+            const messagesContainer = document.getElementById('reportMessages');
+            const antiForgeryToken = document.querySelector('input[name="__RequestVerificationToken"]').value;
+
+            let queryBuilderInstance = null;
+            let columnsSelectInstance = null;
+            let resultsGrid = null;
+            let currentDatasetKey = null;
+            let currentDatasetFields = [];
+            let currentQueryId = null;
+
+            function showMessage(type, text) {
+                messagesContainer.innerHTML = '';
+                if (!text) {
+                    return;
+                }
+                const alert = document.createElement('div');
+                alert.className = `alert alert-${type} alert-dismissible fade show`;
+                alert.setAttribute('role', 'alert');
+                alert.textContent = text;
+
+                const closeButton = document.createElement('button');
+                closeButton.type = 'button';
+                closeButton.className = 'btn-close';
+                closeButton.setAttribute('data-bs-dismiss', 'alert');
+                closeButton.setAttribute('aria-label', 'Close');
+                alert.appendChild(closeButton);
+
+                messagesContainer.appendChild(alert);
+            }
+
+            function clearMessage() {
+                messagesContainer.innerHTML = '';
+            }
+
+            function destroyQueryBuilder() {
+                if (queryBuilderInstance) {
+                    queryBuilderInstance.destroy();
+                    queryBuilderInstance = null;
+                }
+                document.getElementById('queryBuilder').innerHTML = '';
+            }
+
+            function destroyColumnsSelect() {
+                if (columnsSelectInstance) {
+                    columnsSelectInstance.destroy();
+                    columnsSelectInstance = null;
+                }
+                document.getElementById('columnsSelect').value = '';
+            }
+
+            function resetResultsGrid() {
+                if (resultsGrid) {
+                    resultsGrid.destroy();
+                    resultsGrid = null;
+                }
+                document.getElementById('resultsGrid').innerHTML = '';
+            }
+
+            function buildColumnsForQueryBuilder(fields) {
+                return fields.map(field => ({
+                    field: field.field,
+                    label: field.label,
+                    type: field.type,
+                    category: field.category
+                }));
+            }
+
+            function initializeQueryBuilder(fields) {
+                destroyQueryBuilder();
+
+                queryBuilderInstance = new ej.querybuilder.QueryBuilder({
+                    locale: 'ar',
+                    enableRtl: true,
+                    showButtons: true,
+                    columns: buildColumnsForQueryBuilder(fields)
+                });
+
+                queryBuilderInstance.appendTo('#queryBuilder');
+            }
+
+            function initializeColumnsSelect(fields) {
+                destroyColumnsSelect();
+
+                columnsSelectInstance = new ej.dropdowns.MultiSelect({
+                    dataSource: fields,
+                    fields: { text: 'label', value: 'field' },
+                    mode: 'CheckBox',
+                    showDropDownIcon: true,
+                    enableRtl: true,
+                    locale: 'ar',
+                    allowFiltering: true,
+                    selectAllText: 'تحديد الكل',
+                    unSelectAllText: 'إلغاء التحديد',
+                    placeholder: 'اختر الأعمدة المراد عرضها',
+                    value: fields.map(f => f.field)
+                });
+
+                columnsSelectInstance.appendTo('#columnsSelect');
+                columnsSelectInstance.dataBind();
+            }
+
+            async function loadDataset(datasetKey, preserveSelection = false) {
+                if (!datasetKey) {
+                    currentDatasetKey = null;
+                    currentDatasetFields = [];
+                    datasetDescription.textContent = 'اختر مجموعة البيانات لعرض التفاصيل.';
+                    destroyQueryBuilder();
+                    destroyColumnsSelect();
+                    resetResultsGrid();
+                    savedQueriesSelect.innerHTML = '<option value="">-- اختر استعلاماً محفوظاً --</option>';
+                    currentQueryId = null;
+                    queryNameInput.value = '';
+                    return;
+                }
+
+                try {
+                    const response = await fetch(`@Url.Action("GetQueryDataset")?key=${datasetKey}`);
+                    if (!response.ok) {
+                        throw new Error('تعذر تحميل تفاصيل مجموعة البيانات.');
+                    }
+
+                    const dataset = await response.json();
+                    currentDatasetKey = dataset.Key;
+                    currentDatasetFields = dataset.Fields.map(f => ({
+                        field: f.field,
+                        label: f.label,
+                        type: f.type,
+                        category: f.category
+                    }));
+
+                    datasetDescription.textContent = dataset.Description || 'لا يوجد وصف متاح لهذه المجموعة.';
+
+                    initializeQueryBuilder(currentDatasetFields);
+                    initializeColumnsSelect(currentDatasetFields);
+                    if (!preserveSelection) {
+                        currentQueryId = null;
+                        queryNameInput.value = '';
+                        savedQueriesSelect.value = '';
+                    }
+
+                    await loadSavedQueries(datasetKey, preserveSelection);
+                } catch (error) {
+                    showMessage('danger', error.message);
+                }
+            }
+
+            async function loadSavedQueries(datasetKey, preserveSelection = false) {
+                savedQueriesSelect.innerHTML = '<option value="">-- اختر استعلاماً محفوظاً --</option>';
+
+                try {
+                    const response = await fetch(`@Url.Action("GetReportQueries")?datasetKey=${datasetKey}`);
+                    if (!response.ok) {
+                        throw new Error('تعذر تحميل الاستعلامات المحفوظة.');
+                    }
+
+                    const items = await response.json();
+                    items.forEach(item => {
+                        const option = document.createElement('option');
+                        option.value = item.Id;
+                        option.textContent = `${item.Name}`;
+                        savedQueriesSelect.appendChild(option);
+                    });
+
+                    if (preserveSelection && currentQueryId) {
+                        savedQueriesSelect.value = currentQueryId;
+                    }
+                } catch (error) {
+                    showMessage('danger', error.message);
+                }
+            }
+
+            function getSelectedColumns() {
+                if (!columnsSelectInstance) {
+                    return [];
+                }
+                const values = columnsSelectInstance.value || [];
+                return Array.isArray(values) ? values : [];
+            }
+
+            function setColumnsSelection(values) {
+                if (!columnsSelectInstance) {
+                    return;
+                }
+                columnsSelectInstance.value = values;
+                columnsSelectInstance.dataBind();
+            }
+
+            function getRulesJson() {
+                if (!queryBuilderInstance) {
+                    return null;
+                }
+
+                const rules = queryBuilderInstance.getRules();
+                if (!rules || !rules.rules || !rules.rules.length) {
+                    return JSON.stringify({ condition: 'and', rules: [] });
+                }
+
+                return JSON.stringify(rules);
+            }
+
+            function getFieldType(fieldName) {
+                const field = currentDatasetFields.find(f => f.field === fieldName);
+                return field ? field.type : 'string';
+            }
+
+            function getGridColumns(columns) {
+                return columns.map(column => {
+                    const type = getFieldType(column.field);
+                    const config = {
+                        field: column.field,
+                        headerText: column.label,
+                        textAlign: 'Left',
+                        width: 160
+                    };
+
+                    if (type === 'number') {
+                        config.format = 'N2';
+                        config.textAlign = 'Right';
+                    } else if (type === 'date') {
+                        config.format = { type: 'date', format: 'yyyy-MM-dd' };
+                    } else if (type === 'boolean') {
+                        config.textAlign = 'Center';
+                    }
+
+                    return config;
+                });
+            }
+
+            function renderResultsGrid(data) {
+                resetResultsGrid();
+
+                if (!data || !data.rows || !data.rows.length) {
+                    document.getElementById('resultsGrid').innerHTML = '<div class="alert alert-info mb-0">لا توجد بيانات مطابقة للشروط المحددة.</div>';
+                    return;
+                }
+
+                resultsGrid = new ej.grids.Grid({
+                    dataSource: data.rows,
+                    enableRtl: true,
+                    locale: 'ar',
+                    allowPaging: true,
+                    allowSorting: true,
+                    pageSettings: { pageSize: 20, pageSizes: true },
+                    allowFiltering: true,
+                    filterSettings: { type: 'Menu' },
+                    toolbar: ['Search'],
+                    columns: getGridColumns(data.columns)
+                });
+
+                resultsGrid.appendTo('#resultsGrid');
+            }
+
+            async function executeQuery() {
+                clearMessage();
+
+                if (!currentDatasetKey) {
+                    showMessage('warning', 'يرجى اختيار مجموعة البيانات أولاً.');
+                    return;
+                }
+
+                const payload = {
+                    datasetKey: currentDatasetKey,
+                    rulesJson: getRulesJson(),
+                    columns: getSelectedColumns()
+                };
+
+                try {
+                    showLoading();
+                    const response = await fetch('@Url.Action("ExecuteReportQuery")', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'RequestVerificationToken': antiForgeryToken
+                        },
+                        body: JSON.stringify(payload)
+                    });
+
+                    if (!response.ok) {
+                        const error = await response.json().catch(() => null);
+                        throw new Error(error?.message || 'تعذر تنفيذ الاستعلام.');
+                    }
+
+                    const data = await response.json();
+                    renderResultsGrid(data);
+                } catch (error) {
+                    showMessage('danger', error.message);
+                    resetResultsGrid();
+                } finally {
+                    hideLoading();
+                }
+            }
+
+            async function loadReportQuery(queryId) {
+                if (!queryId) {
+                    currentQueryId = null;
+                    queryNameInput.value = '';
+                    setColumnsSelection(currentDatasetFields.map(f => f.field));
+                    if (queryBuilderInstance) {
+                        queryBuilderInstance.setRules({ condition: 'and', rules: [] });
+                    }
+                    return;
+                }
+
+                try {
+                    showLoading();
+                    const response = await fetch(`@Url.Action("GetReportQuery")?id=${queryId}`);
+                    if (!response.ok) {
+                        throw new Error('تعذر تحميل الاستعلام المحدد.');
+                    }
+
+                    const data = await response.json();
+                    await ensureDataset(data.DatasetKey, true);
+
+                    currentQueryId = data.Id;
+                    queryNameInput.value = data.Name;
+
+                    if (data.SelectedColumnsJson) {
+                        try {
+                            const columns = JSON.parse(data.SelectedColumnsJson);
+                            setColumnsSelection(columns);
+                        } catch {
+                            setColumnsSelection(currentDatasetFields.map(f => f.field));
+                        }
+                    } else {
+                        setColumnsSelection(currentDatasetFields.map(f => f.field));
+                    }
+
+                    if (queryBuilderInstance && data.RulesJson) {
+                        try {
+                            const rules = JSON.parse(data.RulesJson);
+                            queryBuilderInstance.setRules(rules);
+                        } catch {
+                            queryBuilderInstance.setRules({ condition: 'and', rules: [] });
+                        }
+                    }
+
+                    savedQueriesSelect.value = data.Id;
+                    showMessage('success', 'تم تحميل الاستعلام بنجاح.');
+                } catch (error) {
+                    showMessage('danger', error.message);
+                } finally {
+                    hideLoading();
+                }
+            }
+
+            async function ensureDataset(datasetKey, preserveSelection = false) {
+                if (datasetSelect.value !== datasetKey) {
+                    datasetSelect.value = datasetKey;
+                    await loadDataset(datasetKey, preserveSelection);
+                }
+            }
+
+            async function saveReportQuery(asNew = false) {
+                clearMessage();
+
+                if (!currentDatasetKey) {
+                    showMessage('warning', 'يرجى اختيار مجموعة البيانات قبل الحفظ.');
+                    return;
+                }
+
+                const name = queryNameInput.value.trim();
+                if (!name) {
+                    showMessage('warning', 'يرجى إدخال اسم للاستعلام.');
+                    return;
+                }
+
+                const payload = {
+                    id: asNew ? null : currentQueryId,
+                    name: name,
+                    datasetKey: currentDatasetKey,
+                    rulesJson: getRulesJson(),
+                    selectedColumnsJson: JSON.stringify(getSelectedColumns())
+                };
+
+                try {
+                    showLoading();
+                    const response = await fetch('@Url.Action("SaveReportQuery")', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'RequestVerificationToken': antiForgeryToken
+                        },
+                        body: JSON.stringify(payload)
+                    });
+
+                    if (!response.ok) {
+                        const error = await response.json().catch(() => null);
+                        throw new Error(error?.message || 'تعذر حفظ الاستعلام.');
+                    }
+
+                    const result = await response.json();
+                    currentQueryId = result.id || result.Id;
+                    showMessage('success', 'تم حفظ الاستعلام بنجاح.');
+                    await loadSavedQueries(currentDatasetKey, true);
+                } catch (error) {
+                    showMessage('danger', error.message);
+                } finally {
+                    hideLoading();
+                }
+            }
+
+            async function deleteReportQuery() {
+                clearMessage();
+
+                if (!currentQueryId) {
+                    showMessage('warning', 'لا يوجد استعلام محدد للحذف.');
+                    return;
+                }
+
+                if (!confirm('هل أنت متأكد من رغبتك في حذف هذا الاستعلام؟')) {
+                    return;
+                }
+
+                try {
+                    showLoading();
+                    const response = await fetch('@Url.Action("DeleteReportQuery")', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'RequestVerificationToken': antiForgeryToken
+                        },
+                        body: JSON.stringify({ id: currentQueryId })
+                    });
+
+                    if (!response.ok) {
+                        throw new Error('تعذر حذف الاستعلام.');
+                    }
+
+                    showMessage('success', 'تم حذف الاستعلام بنجاح.');
+                    currentQueryId = null;
+                    queryNameInput.value = '';
+                    savedQueriesSelect.value = '';
+                    setColumnsSelection(currentDatasetFields.map(f => f.field));
+                    if (queryBuilderInstance) {
+                        queryBuilderInstance.setRules({ condition: 'and', rules: [] });
+                    }
+                    await loadSavedQueries(currentDatasetKey);
+                } catch (error) {
+                    showMessage('danger', error.message);
+                } finally {
+                    hideLoading();
+                }
+            }
+
+            datasetSelect.addEventListener('change', async function () {
+                await loadDataset(this.value);
+            });
+
+            savedQueriesSelect.addEventListener('change', function () {
+                const queryId = this.value;
+                if (queryId) {
+                    loadReportQuery(queryId);
+                } else {
+                    currentQueryId = null;
+                    queryNameInput.value = '';
+                    setColumnsSelection(currentDatasetFields.map(f => f.field));
+                    if (queryBuilderInstance) {
+                        queryBuilderInstance.setRules({ condition: 'and', rules: [] });
+                    }
+                }
+            });
+
+            runQueryBtn.addEventListener('click', executeQuery);
+            saveQueryBtn.addEventListener('click', () => saveReportQuery(false));
+            saveAsQueryBtn.addEventListener('click', () => saveReportQuery(true));
+            deleteQueryBtn.addEventListener('click', deleteReportQuery);
+        })();
+    </script>
+}

--- a/AccountingSystem/Views/Shared/_AccountingLayout.cshtml
+++ b/AccountingSystem/Views/Shared/_AccountingLayout.cshtml
@@ -240,6 +240,7 @@
                                             <li class="report-item nav-item"><a class="nav-link" href="@Url.Action("AccountStatement", "Reports")"><i class="fas fa-file-alt"></i> كشف حساب</a></li>
                                             <li class="report-item nav-item"><a class="nav-link" href="@Url.Action("PendingTransactions", "Reports")"><i class="fas fa-hourglass-half"></i> الحركات غير المرحلة</a></li>
                                             <li class="report-item nav-item"><a class="nav-link" href="@Url.Action("DynamicPivot", "Reports")"><i class="fas fa-hourglass-half"></i>انشاء تقريرPivot </a></li>
+                                            <li class="report-item nav-item"><a class="nav-link" href="@Url.Action("QueryBuilder", "Reports")"><i class="fas fa-project-diagram"></i> مصمم التقارير</a></li>
                                         </ul>
                                     </li>
                                     <li class="nav-item">


### PR DESCRIPTION
## Summary
- add Syncfusion query builder endpoints with saved query lifecycle and rule parsing
- add dataset metadata/service and EF entity + migration to persist saved report queries
- build Query Builder UI and navigation entry so users can run and store reusable reports

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d732c6d17c8333aeaa2016a7efa955