### PR TITLE
Fix dataset field mapping in query builder

### DIFF
--- a/AccountingSystem/Views/Reports/QueryBuilder.cshtml
+++ b/AccountingSystem/Views/Reports/QueryBuilder.cshtml
@@ -234,10 +234,10 @@
                     const dataset = await response.json();
                     currentDatasetKey = dataset.Key;
                     currentDatasetFields = dataset.Fields.map(f => ({
-                        field: f.field,
-                        label: f.label,
-                        type: f.type,
-                        category: f.category
+                        field: f.Field,
+                        label: f.Label,
+                        type: f.Type,
+                        category: f.Category
                     }));
 
                     datasetDescription.textContent = dataset.Description || 'لا يوجد وصف متاح لهذه المجموعة.';


### PR DESCRIPTION
## Summary
- ensure the query builder maps dataset field properties using the server's PascalCase naming

## Testing
- dotnet build *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d737eacb8c83338aa7f68af4e62440