### PR TITLE
Fix query builder grid to reset pager when data loads

### DIFF
--- a/AccountingSystem/Views/Reports/QueryBuilder.cshtml
+++ b/AccountingSystem/Views/Reports/QueryBuilder.cshtml
@@ -352,11 +352,16 @@
                     locale: 'ar',
                     allowPaging: true,
                     allowSorting: true,
-                    pageSettings: { pageSize: 20, pageSizes: true },
+                    pageSettings: { pageSize: 20, pageSizes: true, currentPage: 1 },
                     allowFiltering: true,
                     filterSettings: { type: 'Menu' },
                     toolbar: ['Search'],
-                    columns: getGridColumns(data.columns)
+                    columns: getGridColumns(data.columns),
+                    dataBound: function () {
+                        if (this.pageSettings.currentPage <= 0) {
+                            this.goToPage(1);
+                        }
+                    }
                 });
 
                 resultsGrid.appendTo('#resultsGrid');


### PR DESCRIPTION
## Summary
- ensure the query builder results grid resets its pager to the first page when new data is loaded
- guard against Syncfusion showing page index 0 by forcing a jump to page 1 on data bound

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68d739798c508333b63abd3dd7694ecd