### PR TITLE
Remove settlement account selection from asset expense creation

### DIFF
--- a/AccountingSystem/ViewModels/AssetViewModels.cs
+++ b/AccountingSystem/ViewModels/AssetViewModels.cs
@@ -85,9 +85,6 @@ namespace AccountingSystem.ViewModels
         [Display(Name = "الحساب")]
         public int ExpenseAccountId { get; set; }
 
-        [Display(Name = "حساب التسوية")]
-        public int? AccountId { get; set; }
-
         [Required]
         [Display(Name = "المورد")]
         public int? SupplierId { get; set; }
@@ -114,7 +111,6 @@ namespace AccountingSystem.ViewModels
 
         public IEnumerable<SelectListItem> Assets { get; set; } = Enumerable.Empty<SelectListItem>();
         public IEnumerable<AssetExpenseAccountOption> ExpenseAccounts { get; set; } = Enumerable.Empty<AssetExpenseAccountOption>();
-        public IEnumerable<AssetExpenseAccountOption> Accounts { get; set; } = Enumerable.Empty<AssetExpenseAccountOption>();
         public IEnumerable<AssetExpenseSupplierOption> Suppliers { get; set; } = Enumerable.Empty<AssetExpenseSupplierOption>();
     }
 

--- a/AccountingSystem/Views/AssetExpenses/Create.cshtml
+++ b/AccountingSystem/Views/AssetExpenses/Create.cshtml
@@ -55,20 +55,6 @@
                         <option value="false" selected="@(!Model.IsCash ? "selected" : null)">غير نقدي</option>
                     </select>
                 </div>
-                <div class="col-md-6" id="settlementContainer">
-                    <label asp-for="AccountId" class="form-label"></label>
-                    <select asp-for="AccountId" class="form-select" id="settlementAccountSelect">
-                        <option value="">-- اختر الحساب --</option>
-                        @foreach (var account in Model.Accounts)
-                        {
-                            <option value="@account.Id"
-                                    data-currency-id="@account.CurrencyId"
-                                    data-currency-code="@account.CurrencyCode"
-                                    selected="@(account.Id == Model.AccountId ? "selected" : null)">@account.DisplayName</option>
-                        }
-                    </select>
-                    <span asp-validation-for="AccountId" class="text-danger"></span>
-                </div>
                 <div class="col-md-6">
                     <label class="form-label">العملة</label>
                     <input type="text" class="form-control" id="currencyDisplay" readonly />
@@ -108,9 +94,6 @@
     <script>
         document.addEventListener('DOMContentLoaded', function () {
             const expenseSelect = document.getElementById('expenseAccountSelect');
-            const settlementContainer = document.getElementById('settlementContainer');
-            const settlementSelect = document.getElementById('settlementAccountSelect');
-            const paymentType = document.getElementById('paymentType');
             const currencyDisplay = document.getElementById('currencyDisplay');
             const currencyId = document.getElementById('currencyId');
             const supplierSelect = document.getElementById('supplierSelect');
@@ -122,27 +105,7 @@
                 const currencyValue = option ? option.getAttribute('data-currency-id') : '';
                 currencyDisplay.value = currencyCode || '';
                 currencyId.value = currencyValue || '';
-                filterSettlementAccounts(currencyValue);
                 filterSuppliers(currencyValue);
-            }
-
-            function filterSettlementAccounts(currencyValue) {
-                if (!settlementSelect) return;
-                let firstVisible = null;
-                Array.from(settlementSelect.options).forEach(opt => {
-                    if (!opt.value) {
-                        opt.hidden = false;
-                        return;
-                    }
-                    const matches = !currencyValue || opt.getAttribute('data-currency-id') === currencyValue;
-                    opt.hidden = !matches;
-                    if (matches && !firstVisible) {
-                        firstVisible = opt;
-                    }
-                });
-                if (firstVisible && settlementSelect.value && settlementSelect.options[settlementSelect.selectedIndex].hidden) {
-                    settlementSelect.value = firstVisible.value;
-                }
             }
 
             function filterSuppliers(currencyValue) {
@@ -164,25 +127,11 @@
                 }
             }
 
-            function toggleSettlement() {
-                if (!settlementContainer) return;
-                if (paymentType.value === 'true') {
-                    settlementContainer.classList.add('d-none');
-                } else {
-                    settlementContainer.classList.remove('d-none');
-                    filterSettlementAccounts(currencyId.value);
-                }
-            }
-
             if (expenseSelect) {
                 expenseSelect.addEventListener('change', updateCurrency);
             }
-            if (paymentType) {
-                paymentType.addEventListener('change', toggleSettlement);
-            }
 
             updateCurrency();
-            toggleSettlement();
             filterSuppliers(currencyId.value);
         });
     </script>


### PR DESCRIPTION
## Summary
- remove the settlement account picker from the asset expense creation view and related client-side filtering
- update the asset expense creation workflow to stop validating or posting settlement accounts, keeping journal entries aligned with supplier payments
- simplify the asset expense view model to reflect the streamlined inputs

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d803fe7ac483339f3bca088177d292