### PR TITLE
Add branch revenue vs expense comparison chart

### DIFF
--- a/AccountingSystem/Controllers/HomeController.cs
+++ b/AccountingSystem/Controllers/HomeController.cs
@@ -160,6 +160,15 @@ public class HomeController : Controller
             })
             .ToList();
 
+        var branchFinancials = branchGroups
+            .Select(g => new BranchFinancialComparison
+            {
+                Branch = g.Branch,
+                Revenue = Math.Round(g.Revenue, 2, MidpointRounding.AwayFromZero),
+                Expenses = Math.Round(g.Expenses, 2, MidpointRounding.AwayFromZero)
+            })
+            .ToList();
+
         var totalJournalEntries = await _context.JournalEntries
             .Where(e => e.Date >= startDate && e.Date <= endDate)
             .CountAsync();
@@ -205,7 +214,8 @@ public class HomeController : Controller
             IncomeSources = incomeSources,
             SalesScatter = receiptVouchers,
             RiskReturn = riskReturn,
-            BalancedScorecard = balancedScorecard
+            BalancedScorecard = balancedScorecard,
+            BranchFinancials = branchFinancials
         };
 
         return View(viewModel);

--- a/AccountingSystem/ViewModels/HomeDashboardViewModel.cs
+++ b/AccountingSystem/ViewModels/HomeDashboardViewModel.cs
@@ -51,6 +51,13 @@ namespace AccountingSystem.ViewModels
         public decimal Score { get; set; }
     }
 
+    public class BranchFinancialComparison
+    {
+        public string Branch { get; set; } = string.Empty;
+        public decimal Revenue { get; set; }
+        public decimal Expenses { get; set; }
+    }
+
     public class HomeDashboardViewModel
     {
         public DateTime FromDate { get; set; }
@@ -62,5 +69,6 @@ namespace AccountingSystem.ViewModels
         public List<SalesScatterPoint> SalesScatter { get; set; } = new();
         public List<RiskReturnPoint> RiskReturn { get; set; } = new();
         public List<BalancedScorecardMetric> BalancedScorecard { get; set; } = new();
+        public List<BranchFinancialComparison> BranchFinancials { get; set; } = new();
     }
 }

--- a/AccountingSystem/Views/Home/Index.cshtml
+++ b/AccountingSystem/Views/Home/Index.cshtml
@@ -96,6 +96,18 @@
         </div>
 
         <div class="col-6">
+            <div class="card chart-card" data-collapse-id="branch-comparison-chart">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <h5 class="mb-0">الإيرادات مقابل المصروفات حسب الفرع</h5>
+                    <button class="btn btn-sm btn-outline-primary" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-branch-comparison-chart" aria-expanded="true" aria-controls="collapse-branch-comparison-chart">إظهار / إخفاء</button>
+                </div>
+                <div id="collapse-branch-comparison-chart" class="collapse show">
+                    <div id="branchComparisonChart" class="chart-host"></div>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-6">
             <div class="card chart-card" data-collapse-id="pie-chart">
                 <div class="card-header d-flex justify-content-between align-items-center">
                     <h5 class="mb-0">الحصة السوقية </h5>
@@ -246,6 +258,7 @@
             const salesScatterRaw = @Html.Raw(JsonSerializer.Serialize(Model.SalesScatter, jsonOptions));
             const riskReturn = @Html.Raw(JsonSerializer.Serialize(Model.RiskReturn, jsonOptions));
             const balancedScorecard = @Html.Raw(JsonSerializer.Serialize(Model.BalancedScorecard, jsonOptions));
+            const branchFinancials = @Html.Raw(JsonSerializer.Serialize(Model.BranchFinancials, jsonOptions));
 
             const numberFormatter = new Intl.NumberFormat('ar-EG', { maximumFractionDigits: 2 });
             const axisDateFormatter = new Intl.DateTimeFormat('ar-EG', { year: 'numeric', month: 'short' });
@@ -502,6 +515,29 @@
                     yName: 'score',
                     dataLabel: { visible: true, position: 'Top' }
                 }]
+            });
+
+            createChart('#branchComparisonChart', {
+                primaryXAxis: { valueType: 'Category' },
+                primaryYAxis: { },
+                title: 'مقارنة الإيرادات والمصروفات حسب الفرع',
+                legendSettings: { visible: true },
+                series: [
+                    {
+                        type: 'Column',
+                        dataSource: branchFinancials,
+                        xName: 'branch',
+                        yName: 'revenue',
+                        name: 'الإيرادات'
+                    },
+                    {
+                        type: 'Column',
+                        dataSource: branchFinancials,
+                        xName: 'branch',
+                        yName: 'expenses',
+                        name: 'المصروفات'
+                    }
+                ]
             });
 
             createAccumulationChart('#pieChart', {


### PR DESCRIPTION
## Summary
- add a view model projection for branch-level revenue and expense totals
- populate the new dataset in the home dashboard action
- render a new collapsible chart comparing revenue vs expenses per branch on the home page

## Testing
- not run (dotnet CLI not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d804107bc88333ae8b0cabb2ecc3b6