### PR TITLE
Remove remember me option and add password visibility toggle

### DIFF
--- a/AccountingSystem/Controllers/AccountController.cs
+++ b/AccountingSystem/Controllers/AccountController.cs
@@ -45,7 +45,7 @@ namespace AccountingSystem.Controllers
                 var user = await _userManager.FindByEmailAsync(model.Email);
                 if (user != null && user.IsActive)
                 {
-                    var result = await _signInManager.PasswordSignInAsync(user, model.Password, model.RememberMe, lockoutOnFailure: false);
+                    var result = await _signInManager.PasswordSignInAsync(user, model.Password, isPersistent: false, lockoutOnFailure: false);
 
                     if (result.Succeeded)
                     {

--- a/AccountingSystem/ViewModels/LoginViewModel.cs
+++ b/AccountingSystem/ViewModels/LoginViewModel.cs
@@ -14,8 +14,6 @@ namespace AccountingSystem.ViewModels
         [Display(Name = "كلمة المرور")]
         public string Password { get; set; } = string.Empty;
 
-        [Display(Name = "تذكرني")]
-        public bool RememberMe { get; set; }
     }
 }
 

--- a/AccountingSystem/Views/Account/Login.cshtml
+++ b/AccountingSystem/Views/Account/Login.cshtml
@@ -302,15 +302,15 @@
                         <span asp-validation-for="Email" class="text-danger small"></span>
                     </div>
 
-                    <div class="mb-2">
+                    <div class="mb-3">
                         <label asp-for="Password" class="form-label">كلمة المرور</label>
-                        <input asp-for="Password" class="form-control" placeholder="••••••••" autocomplete="current-password" />
+                        <div class="input-group">
+                            <input asp-for="Password" class="form-control" placeholder="••••••••" autocomplete="current-password" />
+                            <button type="button" class="btn btn-outline-secondary toggle-password" data-target="Password" aria-label="إظهار كلمة المرور">
+                                <i class="fa-regular fa-eye"></i>
+                            </button>
+                        </div>
                         <span asp-validation-for="Password" class="text-danger small"></span>
-                    </div>
-
-                    <div class="form-check my-3">
-                        <input asp-for="RememberMe" class="form-check-input" id="RememberMe" />
-                        <label asp-for="RememberMe" class="form-check-label">تذكرني</label>
                     </div>
 
                     <button id="btnLogin" type="submit" class="btn btn-brand w-100">
@@ -358,6 +358,21 @@
                     isLoading ? ($btn.attr('disabled', true), $sp.removeClass('d-none'))
                               : ($btn.removeAttr('disabled'), $sp.addClass('d-none'));
                 }
+
+                // تبديل عرض كلمة المرور
+                $('.toggle-password').on('click', function () {
+                    const targetId = $(this).data('target');
+                    const $input = $('#' + targetId);
+                    if (!$input.length) return;
+
+                    const isPassword = $input.attr('type') === 'password';
+                    $input.attr('type', isPassword ? 'text' : 'password');
+
+                    const $icon = $(this).find('i');
+                    $icon.toggleClass('fa-eye fa-eye-slash');
+
+                    $(this).attr('aria-label', isPassword ? 'إخفاء كلمة المرور' : 'إظهار كلمة المرور');
+                });
 
                 // CSRF تلقائيًا
                 $.ajaxSetup({


### PR DESCRIPTION
## Summary
- remove the Remember Me checkbox from the login view and streamline the view model
- add a password visibility toggle button for the login password field
- update the sign-in flow to always use non-persistent sessions

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d97aac92888333af74f563b2d585d3