### PR TITLE
Restrict UI actions to authorized permissions

### DIFF
--- a/AccountingSystem/TagHelpers/PermissionTagHelper.cs
+++ b/AccountingSystem/TagHelpers/PermissionTagHelper.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace AccountingSystem.TagHelpers
+{
+    [HtmlTargetElement(Attributes = "asp-require-permission")]
+    public class PermissionTagHelper : TagHelper
+    {
+        private readonly IAuthorizationService _authorizationService;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public PermissionTagHelper(
+            IAuthorizationService authorizationService,
+            IHttpContextAccessor httpContextAccessor)
+        {
+            _authorizationService = authorizationService;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        [HtmlAttributeName("asp-require-permission")]
+        public string? Permission { get; set; }
+
+        public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+        {
+            if (string.IsNullOrWhiteSpace(Permission))
+            {
+                return;
+            }
+
+            var httpContext = _httpContextAccessor.HttpContext;
+            if (httpContext is null)
+            {
+                output.SuppressOutput();
+                return;
+            }
+
+            var authorizationResult = await _authorizationService.AuthorizeAsync(httpContext.User, Permission);
+            if (!authorizationResult.Succeeded)
+            {
+                output.SuppressOutput();
+            }
+        }
+    }
+}

--- a/AccountingSystem/Views/Accounts/Details.cshtml
+++ b/AccountingSystem/Views/Accounts/Details.cshtml
@@ -12,7 +12,7 @@
                 <div class="card-header d-flex justify-content-between align-items-center">
                     <h3 class="card-title">تفاصيل الحساب: @Model.NameAr</h3>
                     <div class="btn-group">
-                        <a href="@Url.Action("Edit", new { id = Model.Id })" class="btn btn-warning">
+                        <a href="@Url.Action("Edit", new { id = Model.Id })" class="btn btn-warning" asp-require-permission="accounts.edit">
                             <i class="fas fa-edit"></i> تعديل
                         </a>
                         @if (Model.CanPostTransactions)
@@ -21,7 +21,7 @@
                                 <i class="fas fa-file-alt"></i> كشف الحساب
                             </a>
                         }
-                        <a href="@Url.Action("Create", new { parentId = Model.Id })" class="btn btn-primary">
+                        <a href="@Url.Action("Create", new { parentId = Model.Id })" class="btn btn-primary" asp-require-permission="accounts.create">
                             <i class="fas fa-plus"></i> إضافة حساب فرعي
                         </a>
                         <a href="@Url.Action("Index")" class="btn btn-secondary">

--- a/AccountingSystem/Views/Accounts/Index.cshtml
+++ b/AccountingSystem/Views/Accounts/Index.cshtml
@@ -12,7 +12,7 @@
                 <div class="card-header d-flex justify-content-between align-items-center">
                     <h3 class="card-title">قائمة الحسابات</h3>
                     <div class="btn-group">
-                        <a href="@Url.Action("Create")" class="btn btn-primary">
+                        <a href="@Url.Action("Create")" class="btn btn-primary" asp-require-permission="accounts.create">
                             <i class="fas fa-plus"></i> إضافة حساب جديد
                         </a>
                         <a href="@Url.Action("Tree")" class="btn btn-success">
@@ -97,12 +97,14 @@
                                                        class="btn btn-info btn-sm" title="التفاصيل">
                                                         <i class="fas fa-eye"></i>
                                                     </a>
-                                                    <a href="@Url.Action("Edit", new { id = account.Id })" 
-                                                       class="btn btn-warning btn-sm" title="تعديل">
+                                                    <a href="@Url.Action("Edit", new { id = account.Id })"
+                                                       class="btn btn-warning btn-sm" title="تعديل"
+                                                       asp-require-permission="accounts.edit">
                                                         <i class="fas fa-edit"></i>
                                                     </a>
-                                                    <a href="@Url.Action("Create", new { parentId = account.Id })" 
-                                                       class="btn btn-primary btn-sm" title="إضافة حساب فرعي">
+                                                    <a href="@Url.Action("Create", new { parentId = account.Id })"
+                                                       class="btn btn-primary btn-sm" title="إضافة حساب فرعي"
+                                                       asp-require-permission="accounts.create">
                                                         <i class="fas fa-plus"></i>
                                                     </a>
                                                     @if (account.CanPostTransactions)
@@ -112,8 +114,9 @@
                                                             <i class="fas fa-file-alt"></i>
                                                         </a>
                                                     }
-                                                    <button type="button" class="btn btn-danger btn-sm" 
-                                                            onclick="deleteAccount(@account.Id)" title="حذف">
+                                                    <button type="button" class="btn btn-danger btn-sm"
+                                                            onclick="deleteAccount(@account.Id)" title="حذف"
+                                                            asp-require-permission="accounts.delete">
                                                         <i class="fas fa-trash"></i>
                                                     </button>
                                                 </div>

--- a/AccountingSystem/Views/AssetExpenses/Index.cshtml
+++ b/AccountingSystem/Views/AssetExpenses/Index.cshtml
@@ -9,7 +9,7 @@
     <div class="card">
         <div class="card-header d-flex justify-content-between align-items-center">
             <h3 class="card-title">مصاريف الأصول</h3>
-            <a asp-action="Create" class="btn btn-primary">
+            <a asp-action="Create" class="btn btn-primary" asp-require-permission="assetexpenses.create">
                 <i class="fas fa-plus"></i> إضافة مصروف
             </a>
         </div>

--- a/AccountingSystem/Views/Assets/Index.cshtml
+++ b/AccountingSystem/Views/Assets/Index.cshtml
@@ -9,7 +9,7 @@
     <div class="card">
         <div class="card-header d-flex justify-content-between align-items-center">
             <h3 class="card-title"> إدارة الأصول الثابته</h3>
-            <a asp-action="Create" class="btn btn-primary">
+            <a asp-action="Create" class="btn btn-primary" asp-require-permission="assets.create">
                 <i class="fas fa-plus"></i> إضافة أصل ثابت
             </a>
         </div>
@@ -43,10 +43,10 @@
                                     <td>@asset.CreatedAt.ToString("yyyy-MM-dd")</td>
                                     <td>
                                         <div class="btn-group btn-group-sm" role="group">
-                                            <a asp-action="Edit" asp-route-id="@asset.Id" class="btn btn-warning">
+                                            <a asp-action="Edit" asp-route-id="@asset.Id" class="btn btn-warning" asp-require-permission="assets.edit">
                                                 <i class="fas fa-edit"></i>
                                             </a>
-                                            <a asp-action="Delete" asp-route-id="@asset.Id" class="btn btn-danger">
+                                            <a asp-action="Delete" asp-route-id="@asset.Id" class="btn btn-danger" asp-require-permission="assets.delete">
                                                 <i class="fas fa-trash"></i>
                                             </a>
                                         </div>

--- a/AccountingSystem/Views/Branches/Details.cshtml
+++ b/AccountingSystem/Views/Branches/Details.cshtml
@@ -11,7 +11,7 @@
                 <div class="card-header d-flex justify-content-between align-items-center">
                     <h3 class="card-title">تفاصيل الفرع: @Model.NameAr</h3>
                     <div class="btn-group">
-                        <a href="@Url.Action("Edit", new { id = Model.Id })" class="btn btn-warning">
+                        <a href="@Url.Action("Edit", new { id = Model.Id })" class="btn btn-warning" asp-require-permission="branches.edit">
                             <i class="fas fa-edit"></i> تعديل
                         </a>
                         <a href="@Url.Action("Index")" class="btn btn-secondary">

--- a/AccountingSystem/Views/Branches/Index.cshtml
+++ b/AccountingSystem/Views/Branches/Index.cshtml
@@ -11,7 +11,7 @@
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center">
                     <h3 class="card-title">إدارة الفروع</h3>
-                    <a href="@Url.Action("Create")" class="btn btn-primary">
+                    <a href="@Url.Action("Create")" class="btn btn-primary" asp-require-permission="branches.create">
                         <i class="fas fa-plus"></i> إضافة فرع جديد
                     </a>
                 </div>
@@ -62,12 +62,14 @@
                                                        class="btn btn-info btn-sm" title="التفاصيل">
                                                         <i class="fas fa-eye"></i>
                                                     </a>
-                                                    <a href="@Url.Action("Edit", new { id = branch.Id })" 
-                                                       class="btn btn-warning btn-sm" title="تعديل">
+                                                    <a href="@Url.Action("Edit", new { id = branch.Id })"
+                                                       class="btn btn-warning btn-sm" title="تعديل"
+                                                       asp-require-permission="branches.edit">
                                                         <i class="fas fa-edit"></i>
                                                     </a>
-                                                    <button type="button" class="btn btn-danger btn-sm" 
-                                                            onclick="deleteBranch(@branch.Id)" title="حذف">
+                                                    <button type="button" class="btn btn-danger btn-sm"
+                                                            onclick="deleteBranch(@branch.Id)" title="حذف"
+                                                            asp-require-permission="branches.delete">
                                                         <i class="fas fa-trash"></i>
                                                     </button>
                                                 </div>

--- a/AccountingSystem/Views/CashBoxClosures/Pending.cshtml
+++ b/AccountingSystem/Views/CashBoxClosures/Pending.cshtml
@@ -36,18 +36,18 @@
                                 <td>@item.Account.CurrentBalance.ToString("N2")</td>
                                 <td class="@(diff == 0 ? "text-success" : "text-danger")">@diff.ToString("N2")</td>
                                 <td>
-                                    <form asp-action="Approve" method="post" class="d-inline">
+                                    <form asp-action="Approve" method="post" class="d-inline" asp-require-permission="cashclosures.approve">
                                         <input type="hidden" name="id" value="@item.Id" />
                                         <input type="hidden" name="matched" value="true" />
                                         <button type="submit" class="btn btn-success btn-sm">موافقة مطابقة</button>
                                     </form>
-                                    <form asp-action="Approve" method="post" class="d-inline mt-1">
+                                    <form asp-action="Approve" method="post" class="d-inline mt-1" asp-require-permission="cashclosures.approve">
                                         <input type="hidden" name="id" value="@item.Id" />
                                         <input type="hidden" name="matched" value="false" />
                                         <input type="text" required name="reason" class="form-control form-control-sm d-inline w-auto" placeholder="سبب" />
                                         <button type="submit" class="btn btn-warning btn-sm">موافقة مع فرق</button>
                                     </form>
-                                    <form asp-action="Reject" method="post" class="d-inline mt-1">
+                                    <form asp-action="Reject" method="post" class="d-inline mt-1" asp-require-permission="cashclosures.approve">
                                         <input type="hidden" name="id" value="@item.Id" />
                                         <input type="text" required name="reason" class="form-control form-control-sm d-inline w-auto" placeholder="سبب" />
                                         <button type="submit" class="btn btn-danger btn-sm">رفض</button>

--- a/AccountingSystem/Views/CostCenters/Details.cshtml
+++ b/AccountingSystem/Views/CostCenters/Details.cshtml
@@ -12,7 +12,7 @@
                 <div class="card-header d-flex justify-content-between align-items-center">
                     <h3 class="card-title">تفاصيل مركز التكلفة: @Model.NameAr</h3>
                     <div class="btn-group">
-                        <a href="@Url.Action("Edit", new { id = Model.Id })" class="btn btn-warning">
+                        <a href="@Url.Action("Edit", new { id = Model.Id })" class="btn btn-warning" asp-require-permission="costcenters.edit">
                             <i class="fas fa-edit"></i> تعديل
                         </a>
                         <a href="@Url.Action("GetCostCenterReport", new { id = Model.Id })" class="btn btn-success">

--- a/AccountingSystem/Views/CostCenters/Index.cshtml
+++ b/AccountingSystem/Views/CostCenters/Index.cshtml
@@ -10,7 +10,7 @@
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center">
                     <h3 class="card-title">إدارة مراكز التكلفة</h3>
-                    <a href="@Url.Action("Create")" class="btn btn-primary">
+                    <a href="@Url.Action("Create")" class="btn btn-primary" asp-require-permission="costcenters.create">
                         <i class="fas fa-plus"></i> إضافة مركز تكلفة جديد
                     </a>
                 </div>
@@ -59,16 +59,18 @@
                                                        class="btn btn-info btn-sm" title="التفاصيل">
                                                         <i class="fas fa-eye"></i>
                                                     </a>
-                                                    <a href="@Url.Action("Edit", new { id = costCenter.Id })" 
-                                                       class="btn btn-warning btn-sm" title="تعديل">
+                                                    <a href="@Url.Action("Edit", new { id = costCenter.Id })"
+                                                       class="btn btn-warning btn-sm" title="تعديل"
+                                                       asp-require-permission="costcenters.edit">
                                                         <i class="fas fa-edit"></i>
                                                     </a>
                                                     <a href="@Url.Action("GetCostCenterReport", new { id = costCenter.Id })" 
                                                        class="btn btn-success btn-sm" title="التقرير">
                                                         <i class="fas fa-chart-bar"></i>
                                                     </a>
-                                                    <button type="button" class="btn btn-danger btn-sm" 
-                                                            onclick="deleteCostCenter(@costCenter.Id)" title="حذف">
+                                                    <button type="button" class="btn btn-danger btn-sm"
+                                                            onclick="deleteCostCenter(@costCenter.Id)" title="حذف"
+                                                            asp-require-permission="costcenters.delete">
                                                         <i class="fas fa-trash"></i>
                                                     </button>
                                                 </div>

--- a/AccountingSystem/Views/Currencies/Index.cshtml
+++ b/AccountingSystem/Views/Currencies/Index.cshtml
@@ -11,7 +11,7 @@
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center">
                     <h3 class="card-title">إدارة العملات</h3>
-                    <a href="@Url.Action("Create")" class="btn btn-primary">
+                    <a href="@Url.Action("Create")" class="btn btn-primary" asp-require-permission="currencies.create">
                         <i class="fas fa-plus"></i> إضافة عملة جديدة
                     </a>
                 </div>
@@ -48,10 +48,12 @@
                                             </td>
                                             <td>
                                                 <div class="btn-group" role="group">
-                                                    <a href="@Url.Action("Edit", new { id = currency.Id })" class="btn btn-warning btn-sm" title="تعديل">
+                                                    <a href="@Url.Action("Edit", new { id = currency.Id })" class="btn btn-warning btn-sm" title="تعديل"
+                                                       asp-require-permission="currencies.edit">
                                                         <i class="fas fa-edit"></i>
                                                     </a>
-                                                    <button type="button" class="btn btn-danger btn-sm" onclick="deleteCurrency(@currency.Id)" title="حذف">
+                                                    <button type="button" class="btn btn-danger btn-sm" onclick="deleteCurrency(@currency.Id)" title="حذف"
+                                                            asp-require-permission="currencies.delete">
                                                         <i class="fas fa-trash"></i>
                                                     </button>
                                                 </div>

--- a/AccountingSystem/Views/DisbursementVouchers/Index.cshtml
+++ b/AccountingSystem/Views/DisbursementVouchers/Index.cshtml
@@ -5,7 +5,7 @@
 }
 
 <div class="container-fluid">
-    <a asp-action="Create" class="btn btn-primary mb-3">سند دفع جديد</a>
+    <a asp-action="Create" class="btn btn-primary mb-3" asp-require-permission="disbursementvouchers.create">سند دفع جديد</a>
     <table class="table table-striped table-hover">
         <thead class="table-dark">
             <tr>

--- a/AccountingSystem/Views/Expenses/Index.cshtml
+++ b/AccountingSystem/Views/Expenses/Index.cshtml
@@ -6,7 +6,7 @@
 <div class="container-fluid">
     <div class="row mb-3">
         <div class="col">
-            <a href="@Url.Action("Create")" class="btn btn-primary">
+            <a href="@Url.Action("Create")" class="btn btn-primary" asp-require-permission="expenses.create">
                 <i class="fas fa-plus"></i> إضافة مصروف
             </a>
             <a href="@Url.Action("My")" class="btn btn-secondary ms-2">
@@ -52,11 +52,11 @@
                         <td>
                             @if (!item.IsApproved)
                             {
-                                <a class="btn btn-sm btn-primary" asp-action="Edit" asp-route-id="@item.Id">تعديل</a>
-                                <form asp-action="Delete" asp-route-id="@item.Id" method="post" class="d-inline">
+                                <a class="btn btn-sm btn-primary" asp-action="Edit" asp-route-id="@item.Id" asp-require-permission="expenses.edit">تعديل</a>
+                                <form asp-action="Delete" asp-route-id="@item.Id" method="post" class="d-inline" asp-require-permission="expenses.delete">
                                     <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('هل أنت متأكد من الحذف؟');">حذف</button>
                                 </form>
-                                <a class="btn btn-sm btn-success" asp-action="Approve" asp-route-id="@item.Id">اعتماد</a>
+                                <a class="btn btn-sm btn-success" asp-action="Approve" asp-route-id="@item.Id" asp-require-permission="expenses.approve">اعتماد</a>
                             }
                         </td>
                     </tr>

--- a/AccountingSystem/Views/JournalEntries/Index.cshtml
+++ b/AccountingSystem/Views/JournalEntries/Index.cshtml
@@ -33,7 +33,7 @@
                         القيود المالية
                     </h3>
                     <div class="d-flex flex-column flex-md-row align-items-md-center gap-2">
-                        <a asp-action="Create" class="btn btn-primary">
+                        <a asp-action="Create" class="btn btn-primary" asp-require-permission="journal.create">
                             <i class="fas fa-plus me-1"></i>
                             إضافة قيد جديد
                         </a>
@@ -127,14 +127,14 @@
 
     <script id="actionsTemplate" type="text/x-template">
         <div class="d-flex justify-content-center flex-wrap gap-2 table-actions" role="group">
-            <a href="@Url.Action("Details", "JournalEntries")/${Id}" class="btn btn-sm btn-outline-info" title="عرض">
+            <a href="@Url.Action("Details", "JournalEntries")/${Id}" class="btn btn-sm btn-outline-info" title="عرض" asp-require-permission="journal.view">
                 <i class="fas fa-eye"></i>
             </a>
             ${if(IsDraft)}
-            <a href="@Url.Action("Edit", "JournalEntries")/${Id}" class="btn btn-sm btn-outline-warning" title="تعديل">
+            <a href="@Url.Action("Edit", "JournalEntries")/${Id}" class="btn btn-sm btn-outline-warning" title="تعديل" asp-require-permission="journal.edit">
                 <i class="fas fa-edit"></i>
             </a>
-            <button type="button" class="btn btn-sm btn-outline-success btn-post-entry" data-id="${Id}" data-number="${Number}" title="ترحيل">
+            <button type="button" class="btn btn-sm btn-outline-success btn-post-entry" data-id="${Id}" data-number="${Number}" title="ترحيل" asp-require-permission="journal.approve">
                 <i class="fas fa-share"></i>
             </button>
             ${/if}

--- a/AccountingSystem/Views/PaymentVouchers/Index.cshtml
+++ b/AccountingSystem/Views/PaymentVouchers/Index.cshtml
@@ -5,7 +5,7 @@
 }
 
 <div class="container-fluid">
-    <a asp-action="Create" class="btn btn-primary mb-3">سند صرف جديد</a>
+    <a asp-action="Create" class="btn btn-primary mb-3" asp-require-permission="paymentvouchers.create">سند صرف جديد</a>
     <table class="table table-striped table-hover">
         <thead class="table-dark">
             <tr>

--- a/AccountingSystem/Views/ReceiptVouchers/Index.cshtml
+++ b/AccountingSystem/Views/ReceiptVouchers/Index.cshtml
@@ -5,7 +5,7 @@
 }
 
 <div class="container-fluid">
-    <a asp-action="Create" class="btn btn-primary mb-3">سند قبض جديد</a>
+    <a asp-action="Create" class="btn btn-primary mb-3" asp-require-permission="receiptvouchers.create">سند قبض جديد</a>
     <table class="table table-striped table-hover">
         <thead class="table-dark">
             <tr>

--- a/AccountingSystem/Views/Suppliers/Index.cshtml
+++ b/AccountingSystem/Views/Suppliers/Index.cshtml
@@ -5,7 +5,7 @@
 <h1 class="mb-3">الموردين</h1>
 @Html.AntiForgeryToken()
 <p>
-    <a class="btn btn-primary" href="@Url.Action("Create")">إضافة مورد</a>
+    <a class="btn btn-primary" href="@Url.Action("Create")" asp-require-permission="suppliers.create">إضافة مورد</a>
 </p>
 <table class="table table-bordered">
     <thead>
@@ -24,8 +24,8 @@
             <td>@item.Phone</td>
             <td>@item.Email</td>
             <td>
-                <a class="btn btn-sm btn-warning" href="@Url.Action("Edit", new { id = item.Id })">تعديل</a>
-                <button class="btn btn-sm btn-danger" onclick="deleteSupplier(@item.Id)">حذف</button>
+                <a class="btn btn-sm btn-warning" href="@Url.Action("Edit", new { id = item.Id })" asp-require-permission="suppliers.edit">تعديل</a>
+                <button class="btn btn-sm btn-danger" onclick="deleteSupplier(@item.Id)" asp-require-permission="suppliers.delete">حذف</button>
             </td>
         </tr>
     }

--- a/AccountingSystem/Views/SystemSettings/Index.cshtml
+++ b/AccountingSystem/Views/SystemSettings/Index.cshtml
@@ -5,7 +5,7 @@
 <h1 class="mb-3">إعدادات النظام</h1>
 @Html.AntiForgeryToken()
 <p>
-    <a class="btn btn-primary" href="@Url.Action("Create")">إضافة إعداد</a>
+    <a class="btn btn-primary" href="@Url.Action("Create")" asp-require-permission="systemsettings.create">إضافة إعداد</a>
 </p>
 <table class="table table-bordered">
     <thead>
@@ -22,8 +22,8 @@
             <td>@item.Key</td>
             <td>@item.Value</td>
             <td>
-                <a class="btn btn-sm btn-warning" href="@Url.Action("Edit", new { id = item.Id })">تعديل</a>
-                <button class="btn btn-sm btn-danger" onclick="deleteSetting(@item.Id)">حذف</button>
+                <a class="btn btn-sm btn-warning" href="@Url.Action("Edit", new { id = item.Id })" asp-require-permission="systemsettings.edit">تعديل</a>
+                <button class="btn btn-sm btn-danger" onclick="deleteSetting(@item.Id)" asp-require-permission="systemsettings.delete">حذف</button>
             </td>
         </tr>
     }

--- a/AccountingSystem/Views/Transfers/Index.cshtml
+++ b/AccountingSystem/Views/Transfers/Index.cshtml
@@ -30,4 +30,4 @@
     </div>
 </div>
 
-<a asp-action="Create" class="btn btn-primary">إنشاء حوالة</a>
+<a asp-action="Create" class="btn btn-primary" asp-require-permission="transfers.create">إنشاء حوالة</a>

--- a/AccountingSystem/Views/Transfers/_TransferTable.cshtml
+++ b/AccountingSystem/Views/Transfers/_TransferTable.cshtml
@@ -28,15 +28,15 @@
             {
                 if (item.ReceiverId == ViewBag.CurrentUserId)
                 {
-                    <a asp-action="Approve" asp-route-id="@item.Id" asp-route-accept="true">استلام</a>
+                    <a asp-action="Approve" asp-route-id="@item.Id" asp-route-accept="true" asp-require-permission="transfers.approve">استلام</a>
                     <span class="mx-1">|</span>
-                    <a asp-action="Approve" asp-route-id="@item.Id" asp-route-accept="false">رفض</a>
+                    <a asp-action="Approve" asp-route-id="@item.Id" asp-route-accept="false" asp-require-permission="transfers.approve">رفض</a>
                 }
                 else if (item.SenderId == ViewBag.CurrentUserId)
                 {
-                    <a asp-action="Edit" asp-route-id="@item.Id">تعديل</a>
+                    <a asp-action="Edit" asp-route-id="@item.Id" asp-require-permission="transfers.create">تعديل</a>
                     <span class="mx-1">|</span>
-                    <form asp-action="Delete" asp-route-id="@item.Id" method="post" style="display:inline">
+                    <form asp-action="Delete" asp-route-id="@item.Id" method="post" style="display:inline" asp-require-permission="transfers.create">
                         <button type="submit" class="btn btn-link p-0 m-0 align-baseline">حذف</button>
                     </form>
                 }

--- a/AccountingSystem/Views/Users/Index.cshtml
+++ b/AccountingSystem/Views/Users/Index.cshtml
@@ -11,7 +11,7 @@
 
 <h1 class="mb-4">المستخدمون</h1>
 <div class="mb-3">
-    <a class="btn btn-success" asp-action="Create"><i class="fas fa-plus"></i> مستخدم جديد</a>
+    <a class="btn btn-success" asp-action="Create" asp-require-permission="users.create"><i class="fas fa-plus"></i> مستخدم جديد</a>
 </div>
 
 <form id="usersAntiForgery" method="post" class="d-none">
@@ -98,10 +98,10 @@
                                 </td>
                                 <td class="text-center">
                                     <div class="btn-group btn-group-sm user-actions" role="group">
-                                        <a class="btn btn-warning" asp-action="Edit" asp-route-id="@user.Id" title="تعديل"><i class="fas fa-edit"></i></a>
-                                        <a class="btn btn-primary" asp-action="ManagePermissions" asp-route-id="@user.Id" title="الصلاحيات"><i class="fas fa-key"></i></a>
-                                        <a class="btn btn-secondary" asp-action="ResetPassword" asp-route-id="@user.Id" title="إعادة ضبط كلمة المرور"><i class="fas fa-lock"></i></a>
-                                        <button type="button" class="btn @(user.IsActive ? "btn-danger" : "btn-success") js-toggle-user" data-id="@user.Id">
+                                        <a class="btn btn-warning" asp-action="Edit" asp-route-id="@user.Id" title="تعديل" asp-require-permission="users.edit"><i class="fas fa-edit"></i></a>
+                                        <a class="btn btn-primary" asp-action="ManagePermissions" asp-route-id="@user.Id" title="الصلاحيات" asp-require-permission="users.edit"><i class="fas fa-key"></i></a>
+                                        <a class="btn btn-secondary" asp-action="ResetPassword" asp-route-id="@user.Id" title="إعادة ضبط كلمة المرور" asp-require-permission="users.edit"><i class="fas fa-lock"></i></a>
+                                        <button type="button" class="btn @(user.IsActive ? "btn-danger" : "btn-success") js-toggle-user" data-id="@user.Id" asp-require-permission="users.edit">
                                             <i class="fas @(user.IsActive ? "fa-user-slash" : "fa-user")"></i> @(user.IsActive ? "إيقاف" : "تفعيل")
                                         </button>
                                     </div>

--- a/AccountingSystem/Views/_ViewImports.cshtml
+++ b/AccountingSystem/Views/_ViewImports.cshtml
@@ -2,3 +2,4 @@
 @using AccountingSystem.Models
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, Syncfusion.EJ2
+@addTagHelper *, AccountingSystem


### PR DESCRIPTION
## Summary
- add a reusable `asp-require-permission` tag helper to hide markup for unauthorized users
- register the new tag helper for Razor views
- gate create/edit/delete and approval controls across accounting screens so that buttons only render when the signed-in user has the required permission

## Testing
- `dotnet build` *(fails: command not found in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d97aeaa9c083339d0e8e89e25514ec