### PR TITLE
Specify decimal precision for balance fields

### DIFF
--- a/AccountingSystem/Data/ApplicationDbContext.cs
+++ b/AccountingSystem/Data/ApplicationDbContext.cs
@@ -170,6 +170,7 @@ namespace AccountingSystem.Data
                 entity.Property(e => e.NameAr).IsRequired().HasMaxLength(200);
                 entity.Property(e => e.NameEn).HasMaxLength(200);
                 entity.Property(e => e.OpeningBalance).HasColumnType("decimal(18,2)");
+                entity.Property(e => e.CurrentBalance).HasColumnType("decimal(18,2)");
                 entity.Property(e => e.CurrencyId);
 
                 entity.HasOne(e => e.Parent)
@@ -498,6 +499,8 @@ namespace AccountingSystem.Data
 
             builder.Entity<User>(entity =>
             {
+                entity.Property(u => u.ExpenseLimit).HasColumnType("decimal(18,2)");
+
                 entity.HasOne(u => u.PaymentAccount)
                     .WithMany()
                     .HasForeignKey(u => u.PaymentAccountId)

--- a/AccountingSystem/Models/Account.cs
+++ b/AccountingSystem/Models/Account.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AccountingSystem.Models
 {
@@ -38,6 +39,7 @@ namespace AccountingSystem.Models
         public int CurrencyId { get; set; }
 
         // Calculated property for current balance
+        [Column(TypeName = "decimal(18,2)")]
         public decimal CurrentBalance { get; set; } = 0;
 
         public bool IsActive { get; set; } = true;

--- a/AccountingSystem/Models/User.cs
+++ b/AccountingSystem/Models/User.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Identity;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AccountingSystem.Models
 {
@@ -26,6 +27,7 @@ namespace AccountingSystem.Models
         public int? PaymentBranchId { get; set; }
         public string? DriverAccountBranchIds { get; set; }
         public string? BusinessAccountBranchIds { get; set; }
+        [Column(TypeName = "decimal(18,2)")]
         public decimal ExpenseLimit { get; set; } = 0;
 
         // Navigation properties


### PR DESCRIPTION
## Summary
- configure the EF model to store account current balances and user expense limits as decimal(18,2)
- annotate the account and user entities with matching column type metadata to prevent truncation warnings

## Testing
- not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d983181c808333be9c70ae80be83f9