### PR TITLE
Add migration removing AssetType account uniqueness

### DIFF
--- a/AccountingSystem/Migrations/20250928190839_ApplyModelChanges.Designer.cs
+++ b/AccountingSystem/Migrations/20250928190839_ApplyModelChanges.Designer.cs
@@ -4,6 +4,7 @@ using AccountingSystem.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AccountingSystem.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250928190839_ApplyModelChanges")]
+    partial class ApplyModelChanges
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/AccountingSystem/Migrations/20250928190839_ApplyModelChanges.cs
+++ b/AccountingSystem/Migrations/20250928190839_ApplyModelChanges.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AccountingSystem.Migrations
+{
+    /// <inheritdoc />
+    public partial class ApplyModelChanges : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_AssetTypes_AccountId",
+                table: "AssetTypes");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AssetTypes_AccountId",
+                table: "AssetTypes",
+                column: "AccountId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_AssetTypes_AccountId",
+                table: "AssetTypes");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AssetTypes_AccountId",
+                table: "AssetTypes",
+                column: "AccountId",
+                unique: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a new EF Core migration that drops the unique constraint on `AssetTypes.AccountId` so multiple asset types can share the same account
- update the `ApplicationDbContext` model snapshot to reflect the non-unique index configuration

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68d986428ce883339b43459eb7f89954