### PR TITLE
Guard AssetTypes index drop in migration

### DIFF
--- a/AccountingSystem/Migrations/20250928190839_ApplyModelChanges.cs
+++ b/AccountingSystem/Migrations/20250928190839_ApplyModelChanges.cs
@@ -10,9 +10,16 @@ namespace AccountingSystem.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropIndex(
-                name: "IX_AssetTypes_AccountId",
-                table: "AssetTypes");
+            migrationBuilder.Sql(@"
+IF EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = N'IX_AssetTypes_AccountId'
+      AND object_id = OBJECT_ID(N'[dbo].[AssetTypes]')
+)
+BEGIN
+    DROP INDEX [IX_AssetTypes_AccountId] ON [dbo].[AssetTypes];
+END");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AssetTypes_AccountId",
@@ -23,9 +30,16 @@ namespace AccountingSystem.Migrations
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropIndex(
-                name: "IX_AssetTypes_AccountId",
-                table: "AssetTypes");
+            migrationBuilder.Sql(@"
+IF EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = N'IX_AssetTypes_AccountId'
+      AND object_id = OBJECT_ID(N'[dbo].[AssetTypes]')
+)
+BEGIN
+    DROP INDEX [IX_AssetTypes_AccountId] ON [dbo].[AssetTypes];
+END");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AssetTypes_AccountId",


### PR DESCRIPTION
## Summary
- guard the AssetTypes index drop with an existence check so the migration can run on databases missing the index

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d98bec7d7c833380da0f83151a95e3