### PR TITLE
Handle existing assets when introducing asset types

### DIFF
--- a/AccountingSystem/Migrations/20250928193417_asswttype1.cs
+++ b/AccountingSystem/Migrations/20250928193417_asswttype1.cs
@@ -46,7 +46,89 @@ namespace AccountingSystem.Migrations
                 table: "AssetTypes",
                 column: "AccountId");
 
+            migrationBuilder.Sql(@"
+                IF EXISTS (SELECT 1 FROM [Assets] WHERE [AssetTypeId] IS NULL)
+                BEGIN
+                    DECLARE @ParentAccountId INT;
+                    SELECT TOP (1) @ParentAccountId = a.[Id]
+                    FROM [SystemSettings] s
+                    JOIN [Accounts] a ON a.[Code] = s.[Value]
+                    WHERE s.[Key] IN (N'AssetTypesParentAccountCode', N'AssetsParentAccountCode')
+                        AND s.[Value] IS NOT NULL
+                    ORDER BY CASE s.[Key] WHEN N'AssetTypesParentAccountCode' THEN 0 ELSE 1 END;
 
+                    IF @ParentAccountId IS NULL
+                    BEGIN
+                        SELECT TOP (1) @ParentAccountId = [Id]
+                        FROM [Accounts]
+                        WHERE [AccountType] = 1
+                        ORDER BY [Level], [Id];
+                    END
+
+                    IF @ParentAccountId IS NULL
+                    BEGIN
+                        THROW 51000, N'لم يتم العثور على حساب أصل رئيسي لإنشاء نوع الأصل الافتراضي. يرجى إعداد الحسابات قبل تشغيل الترحيل.', 1;
+                    END
+
+                    DECLARE @ParentCode NVARCHAR(20);
+                    DECLARE @ParentLevel INT;
+                    DECLARE @AccountType INT;
+                    DECLARE @Nature INT;
+                    DECLARE @Classification INT;
+                    DECLARE @SubClassification INT;
+                    DECLARE @CurrencyId INT;
+
+                    SELECT
+                        @ParentCode = [Code],
+                        @ParentLevel = [Level],
+                        @AccountType = [AccountType],
+                        @Nature = [Nature],
+                        @Classification = [Classification],
+                        @SubClassification = [SubClassification],
+                        @CurrencyId = [CurrencyId]
+                    FROM [Accounts]
+                    WHERE [Id] = @ParentAccountId;
+
+                    DECLARE @LastChildCode NVARCHAR(20);
+                    SELECT TOP (1) @LastChildCode = [Code]
+                    FROM [Accounts]
+                    WHERE [ParentId] = @ParentAccountId
+                    ORDER BY LEN([Code]) DESC, [Code] DESC;
+
+                    DECLARE @SuffixLength INT = 2;
+                    DECLARE @Next INT = 1;
+
+                    IF @LastChildCode IS NOT NULL AND LEN(@LastChildCode) > LEN(@ParentCode)
+                    BEGIN
+                        SET @SuffixLength = CASE WHEN LEN(@LastChildCode) - LEN(@ParentCode) > 2 THEN LEN(@LastChildCode) - LEN(@ParentCode) ELSE 2 END;
+                        DECLARE @Suffix NVARCHAR(20) = SUBSTRING(@LastChildCode, LEN(@ParentCode) + 1, 20);
+                        IF TRY_CAST(@Suffix AS INT) IS NOT NULL
+                        BEGIN
+                            SET @Next = TRY_CAST(@Suffix AS INT) + 1;
+                        END
+                    END
+
+                    DECLARE @NewCode NVARCHAR(20) = @ParentCode + RIGHT(REPLICATE('0', @SuffixLength) + CAST(@Next AS NVARCHAR(20)), @SuffixLength);
+
+                    DECLARE @Now DATETIME2 = SYSUTCDATETIME();
+
+                    INSERT INTO [Accounts]
+                        ([Code], [NameAr], [NameEn], [Description], [ParentId], [Level], [AccountType], [Nature], [Classification], [SubClassification], [OpeningBalance], [CurrencyId], [CurrentBalance], [IsActive], [CanHaveChildren], [CanPostTransactions], [BranchId], [CreatedAt], [UpdatedAt])
+                    VALUES
+                        (@NewCode, N'نوع أصل افتراضي', N'Default Asset Type', N'حساب تم إنشاؤه تلقائيًا لترحيل الأصول الحالية', @ParentAccountId, @ParentLevel + 1, @AccountType, @Nature, @Classification, @SubClassification, 0, @CurrencyId, 0, 1, 1, 0, NULL, @Now, @Now);
+
+                    DECLARE @NewAccountId INT = SCOPE_IDENTITY();
+
+                    INSERT INTO [AssetTypes] ([Name], [AccountId])
+                    VALUES (N'نوع أصل افتراضي', @NewAccountId);
+
+                    DECLARE @NewAssetTypeId INT = SCOPE_IDENTITY();
+
+                    UPDATE [Assets]
+                    SET [AssetTypeId] = @NewAssetTypeId
+                    WHERE [AssetTypeId] IS NULL;
+                END
+            ");
 
             migrationBuilder.AlterColumn<int>(
                 name: "AssetTypeId",


### PR DESCRIPTION
## Summary
- create a default asset type and backing account when existing assets are present
- backfill legacy assets with the generated asset type before enforcing the new constraint

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d991cc42908333a48967ff8d53f780