### PR TITLE
Remove legacy asset type column

### DIFF
--- a/AccountingSystem/Migrations/20251020120000_RemoveLegacyAssetTypeColumn.cs
+++ b/AccountingSystem/Migrations/20251020120000_RemoveLegacyAssetTypeColumn.cs
@@ -1,0 +1,31 @@
+using AccountingSystem.Data;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AccountingSystem.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20251020120000_RemoveLegacyAssetTypeColumn")]
+    public partial class RemoveLegacyAssetTypeColumn : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Type",
+                table: "Assets");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Type",
+                table: "Assets",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: false,
+                defaultValue: string.Empty);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a migration that removes the obsolete `Type` column from the `Assets` table

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d998770328833396e8a2f8c77dcb29