### PR TITLE
Add applications overview dashboard for module access

### DIFF
--- a/AccountingSystem/ViewModels/SystemAppTileViewModel.cs
+++ b/AccountingSystem/ViewModels/SystemAppTileViewModel.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+namespace AccountingSystem.ViewModels
+{
+    public class SystemAppTileViewModel
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public string Category { get; set; } = string.Empty;
+        public string Icon { get; set; } = string.Empty;
+        public string AccentColor { get; set; } = "#0d6efd";
+        public string Permission { get; set; } = string.Empty;
+        public string Url { get; set; } = string.Empty;
+        public bool HasAccess { get; set; }
+    }
+
+    public class SystemAppOverviewViewModel
+    {
+        public List<SystemAppTileViewModel> Apps { get; set; } = new();
+    }
+}

--- a/AccountingSystem/Views/Home/Applications.cshtml
+++ b/AccountingSystem/Views/Home/Applications.cshtml
@@ -1,0 +1,192 @@
+@model AccountingSystem.ViewModels.SystemAppOverviewViewModel
+@{
+    ViewData["Title"] = "تطبيقات النظام";
+    var groupedApps = Model.Apps
+        .GroupBy(app => app.Category)
+        .OrderBy(group => group.Key)
+        .ToList();
+}
+
+<div class="apps-wrapper py-4">
+    <div class="text-center mb-5">
+        <h1 class="fw-bold">تطبيقات النظام</h1>
+        <p class="text-muted mb-0">استعرض جميع شاشات النظام وتحقق من صلاحياتك لكل شاشة بطريقة منظمة وأنيقة.</p>
+    </div>
+
+    @if (!groupedApps.Any())
+    {
+        <div class="alert alert-info text-center">
+            لا توجد تطبيقات متاحة للعرض حالياً.
+        </div>
+    }
+    else
+    {
+        foreach (var group in groupedApps)
+        {
+            var availableCount = group.Count(app => app.HasAccess);
+            <section class="apps-section mb-5">
+                <div class="d-flex flex-wrap gap-3 justify-content-between align-items-center mb-3">
+                    <div>
+                        <h2 class="section-title mb-0">@group.Key</h2>
+                        <small class="text-muted">مجموعة من الوظائف المتعلقة بـ @group.Key</small>
+                    </div>
+                    <span class="badge rounded-pill availability-badge">
+                        @availableCount من @group.Count() متاحة لك
+                    </span>
+                </div>
+                <div class="app-grid">
+                    @foreach (var app in group)
+                    {
+                        var cardClasses = app.HasAccess ? "has-access" : "no-access";
+                        var linkTarget = app.HasAccess ? app.Url : "#";
+                        <a class="app-card @cardClasses" href="@linkTarget" style="--accent-color: @app.AccentColor;" @(app.HasAccess ? string.Empty : "aria-disabled=\"true\" tabindex=\"-1\"")>
+                            <div class="app-icon">@app.Icon</div>
+                            <div class="app-body">
+                                <h3 class="app-title">@app.Name</h3>
+                                <p class="app-description">@app.Description</p>
+                            </div>
+                            <div class="app-footer d-flex justify-content-between align-items-center">
+                                <span class="status-badge">@(app.HasAccess ? "متاح" : "غير متاح")</span>
+                                <small class="text-muted permission-code">@app.Permission</small>
+                            </div>
+                        </a>
+                    }
+                </div>
+            </section>
+        }
+    }
+</div>
+
+@section Styles {
+    <style>
+        .apps-wrapper {
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+
+        .apps-section {
+            background: #ffffff;
+            border-radius: 1.5rem;
+            padding: 2.5rem;
+            box-shadow: 0 1.5rem 2.5rem rgba(20, 30, 90, 0.05);
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 700;
+            color: #1f2937;
+        }
+
+        .availability-badge {
+            background: rgba(13, 110, 253, 0.1);
+            color: #0d6efd;
+            font-size: 0.95rem;
+            padding: 0.65rem 1.25rem;
+        }
+
+        .app-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+            gap: 1.5rem;
+        }
+
+        .app-card {
+            position: relative;
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+            padding: 1.5rem;
+            background: linear-gradient(145deg, #ffffff, #f5f7fb);
+            border-radius: 1.25rem;
+            box-shadow: 0 1rem 2rem rgba(15, 23, 42, 0.08);
+            border-top: 4px solid var(--accent-color, #0d6efd);
+            text-decoration: none;
+            color: inherit;
+            transition: transform 0.25s ease, box-shadow 0.25s ease;
+        }
+
+        .app-card::before {
+            content: "";
+            position: absolute;
+            inset: 0;
+            border-radius: inherit;
+            background: linear-gradient(135deg, rgba(255, 255, 255, 0.2), rgba(13, 110, 253, 0.05));
+            opacity: 0;
+            transition: opacity 0.3s ease;
+        }
+
+        .app-card.has-access:hover {
+            transform: translateY(-8px);
+            box-shadow: 0 1.5rem 2.5rem rgba(13, 110, 253, 0.18);
+        }
+
+        .app-card.has-access:hover::before {
+            opacity: 1;
+        }
+
+        .app-card.no-access {
+            opacity: 0.65;
+            border-style: dashed;
+            pointer-events: none;
+        }
+
+        .app-icon {
+            width: 3.5rem;
+            height: 3.5rem;
+            border-radius: 1rem;
+            background: var(--accent-color, #0d6efd);
+            color: #ffffff;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 1.75rem;
+            box-shadow: 0 0.75rem 1.5rem rgba(13, 110, 253, 0.25);
+        }
+
+        .app-title {
+            font-size: 1.25rem;
+            font-weight: 700;
+            color: #111827;
+            margin-bottom: 0.5rem;
+        }
+
+        .app-description {
+            color: #6b7280;
+            font-size: 0.95rem;
+            margin-bottom: 0;
+            min-height: 3.5rem;
+        }
+
+        .app-footer {
+            border-top: 1px solid rgba(15, 23, 42, 0.08);
+            padding-top: 0.75rem;
+        }
+
+        .status-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 999px;
+            font-size: 0.85rem;
+            font-weight: 600;
+            color: #fff;
+            background: linear-gradient(135deg, var(--accent-color, #0d6efd), rgba(13, 110, 253, 0.75));
+        }
+
+        .app-card.no-access .status-badge {
+            background: #adb5bd;
+        }
+
+        .permission-code {
+            font-family: 'Cascadia Code', 'Courier New', monospace;
+        }
+
+        @media (max-width: 768px) {
+            .apps-section {
+                padding: 1.75rem;
+            }
+
+            .app-card {
+                padding: 1.25rem;
+            }
+        }
+    </style>
+}

--- a/AccountingSystem/Views/Shared/_Layout.cshtml
+++ b/AccountingSystem/Views/Shared/_Layout.cshtml
@@ -32,6 +32,9 @@
                             <a class="nav-link text-white" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
                         </li>
                         <li class="nav-item">
+                            <a class="nav-link text-white" asp-area="" asp-controller="Home" asp-action="Applications">التطبيقات</a>
+                        </li>
+                        <li class="nav-item">
                             <a class="nav-link text-white" asp-area="" asp-controller="Transfers" asp-action="Index">الحوالات</a>
                         </li>
                     </ul>


### PR DESCRIPTION
## Summary
- introduce view models that describe application tiles and their access state
- add a Home/Applications action that builds module tiles based on user permissions
- create a new Applications view with a modern grid layout and link it from the main navigation

## Testing
- dotnet build *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9a39688408333a1d62343c4b24fc2