### PR TITLE
Revamp layout to mirror Odoo styling

### DIFF
--- a/AccountingSystem/Views/Shared/_Layout.cshtml
+++ b/AccountingSystem/Views/Shared/_Layout.cshtml
@@ -6,57 +6,194 @@
     <title>@ViewData["Title"] - AccountingSystem</title>
     <script type="importmap"></script>
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" integrity="sha384-1N6U7Jt3hOaEb8r6yxCbKUfZZY3mc3l5JMlbLhtYVrtkGLumZ5qX6Ch12RS6X8Gy" crossorigin="anonymous">
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/AccountingSystem.styles.css" asp-append-version="true" />
     <link href="https://cdn.syncfusion.com/ej2/bootstrap5.css" rel="stylesheet" />
     @await RenderSectionAsync("Styles", required: false)
 </head>
-<body>
-    <header>
-        <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-dark border-bottom box-shadow mb-3">
-            <div class="container-fluid">
-                <a class="navbar-brand d-flex align-items-center" asp-area="" asp-controller="Home" asp-action="Index">
-                    <img src="~/images/logo.svg" alt="Road-Finity Logo" class="navbar-logo me-2" />
-                    <span>AccountingSystem</span>
-                </a>
-                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbarSupportedContent"
-                        aria-expanded="false" aria-label="Toggle navigation">
-                    <span class="navbar-toggler-icon"></span>
+<body class="odoo-body">
+    <header class="odoo-topbar shadow-sm">
+        <div class="odoo-topbar__section odoo-topbar__section--left">
+            <button class="btn btn-link odoo-icon-button" type="button" id="sidebarToggle" aria-controls="mainSidebar" aria-expanded="false" title="القائمة الرئيسية">
+                <i class="bi bi-grid-3x3-gap-fill"></i>
+            </button>
+            <a class="odoo-brand d-flex align-items-center" asp-area="" asp-controller="Home" asp-action="Index">
+                <img src="~/images/logo.svg" alt="AccountingSystem Logo" class="odoo-brand__logo me-2" />
+                <span class="odoo-brand__name">AccountingSystem</span>
+            </a>
+        </div>
+        <div class="odoo-topbar__section odoo-topbar__section--center">
+            <div class="odoo-global-search">
+                <i class="bi bi-search"></i>
+                <input type="search" class="form-control" placeholder="ابحث في النظام" aria-label="Global search" />
+            </div>
+        </div>
+        <div class="odoo-topbar__section odoo-topbar__section--right">
+            <button class="btn btn-link odoo-icon-button" type="button" title="المهام">
+                <i class="bi bi-check2-square"></i>
+            </button>
+            <button class="btn btn-link odoo-icon-button" type="button" title="الإشعارات">
+                <i class="bi bi-bell"></i>
+            </button>
+            <button class="btn btn-link odoo-icon-button" type="button" title="الدعم">
+                <i class="bi bi-question-circle"></i>
+            </button>
+            <div class="dropdown">
+                <button class="btn btn-link odoo-user d-flex align-items-center" type="button" id="userMenu" data-bs-toggle="dropdown" aria-expanded="false">
+                    <span class="odoo-user__avatar">AY</span>
+                    <span class="odoo-user__name">Ayman</span>
+                    <i class="bi bi-chevron-down ms-1"></i>
                 </button>
-                <div class="navbar-collapse collapse d-sm-inline-flex justify-content-between">
-                    <ul class="navbar-nav flex-grow-1">
-                        <li class="nav-item">
-                            <a class="nav-link text-white" asp-area="" asp-controller="Home" asp-action="Index">Home</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link text-white" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link text-white" asp-area="" asp-controller="Home" asp-action="Applications">التطبيقات</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link text-white" asp-area="" asp-controller="Transfers" asp-action="Index">الحوالات</a>
-                        </li>
-                    </ul>
+                <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userMenu">
+                    <li><a class="dropdown-item" asp-area="" asp-controller="Account" asp-action="Profile">الملف الشخصي</a></li>
+                    <li><a class="dropdown-item" asp-area="" asp-controller="Account" asp-action="Settings">الإعدادات</a></li>
+                    <li><hr class="dropdown-divider" /></li>
+                    <li><a class="dropdown-item" asp-area="" asp-controller="Account" asp-action="Logout">تسجيل الخروج</a></li>
+                </ul>
+            </div>
+        </div>
+    </header>
+
+    <nav class="odoo-subheader border-bottom">
+        <div class="container-fluid">
+            <div class="odoo-subheader__content">
+                <div class="odoo-subheader__title">
+                    <span class="odoo-subheader__app">المبيعات</span>
+                    <i class="bi bi-chevron-right mx-2"></i>
+                    <span class="odoo-subheader__section">العملاء</span>
+                </div>
+                <div class="odoo-subheader__actions">
+                    <div class="dropdown">
+                        <button class="btn btn-sm btn-outline-secondary dropdown-toggle" type="button" id="viewOptions" data-bs-toggle="dropdown" aria-expanded="false">
+                            عرض القائمة
+                        </button>
+                        <ul class="dropdown-menu" aria-labelledby="viewOptions">
+                            <li><a class="dropdown-item" href="#">عرض الجدول</a></li>
+                            <li><a class="dropdown-item" href="#">عرض الكانبان</a></li>
+                            <li><a class="dropdown-item" href="#">عرض التقويم</a></li>
+                        </ul>
+                    </div>
+                    <a class="btn btn-primary" asp-area="" asp-controller="Clients" asp-action="Create">
+                        <i class="bi bi-plus-lg me-2"></i> عميل جديد
+                    </a>
                 </div>
             </div>
-        </nav>
-    </header>
-    <div class="container">
-        <main role="main" class="pb-3">
-            @RenderBody()
-        </main>
+        </div>
+    </nav>
+
+    <div class="container-fluid odoo-main">
+        <div class="row flex-nowrap">
+            <aside class="col-auto odoo-sidebar" id="mainSidebar" aria-labelledby="mainSidebarLabel">
+                <div class="odoo-sidebar__header d-flex align-items-center justify-content-between mb-3">
+                    <h5 class="mb-0" id="mainSidebarLabel">التطبيقات</h5>
+                    <button type="button" class="btn btn-sm btn-outline-secondary d-lg-none" id="sidebarClose" aria-label="إغلاق القائمة">
+                        <i class="bi bi-x-lg"></i>
+                    </button>
+                </div>
+                <ul class="nav flex-column">
+                    <li class="nav-item"><a class="nav-link" asp-area="" asp-controller="Home" asp-action="Applications"><i class="bi bi-app"></i><span> التطبيقات</span></a></li>
+                    <li class="nav-item"><a class="nav-link" asp-area="" asp-controller="Transfers" asp-action="Index"><i class="bi bi-arrow-left-right"></i><span> الحوالات</span></a></li>
+                    <li class="nav-item"><a class="nav-link" asp-area="" asp-controller="Invoices" asp-action="Index"><i class="bi bi-receipt"></i><span> الفواتير</span></a></li>
+                    <li class="nav-item"><a class="nav-link" asp-area="" asp-controller="Reports" asp-action="Index"><i class="bi bi-graph-up"></i><span> التقارير</span></a></li>
+                    <li class="nav-item"><a class="nav-link" asp-area="" asp-controller="Settings" asp-action="Index"><i class="bi bi-sliders"></i><span> الإعدادات</span></a></li>
+                </ul>
+            </aside>
+            <div class="col odoo-content-wrapper">
+                <main role="main" class="odoo-main__content">
+                    @RenderBody()
+                </main>
+            </div>
+        </div>
     </div>
 
-    <footer class="border-top footer text-muted">
-        <div class="container">
-            &copy; 2025 - AccountingSystem - <a asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
+    <footer class="odoo-footer border-top">
+        <div class="container-fluid d-flex justify-content-between align-items-center">
+            <span>&copy; 2025 - AccountingSystem</span>
+            <a asp-area="" asp-controller="Home" asp-action="Privacy" class="text-decoration-none">سياسة الخصوصية</a>
         </div>
     </footer>
+
+    <div class="odoo-sidebar-backdrop" id="sidebarBackdrop" hidden></div>
     <script src="~/lib/jquery/dist/jquery.min.js"></script>
     <script src="https://cdn.syncfusion.com/ej2/dist/ej2.min.js"></script>
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
+    <script>
+        (() => {
+            const sidebar = document.getElementById('mainSidebar');
+            const toggle = document.getElementById('sidebarToggle');
+            const close = document.getElementById('sidebarClose');
+            const backdrop = document.getElementById('sidebarBackdrop');
+
+            if (!sidebar || !toggle || !backdrop) {
+                return;
+            }
+
+            const shouldUseOverlay = () => window.innerWidth < 992;
+
+            const onTransitionEnd = () => {
+                if (!backdrop.classList.contains('is-visible')) {
+                    backdrop.hidden = true;
+                }
+            };
+
+            const openSidebar = () => {
+                if (!shouldUseOverlay()) {
+                    return;
+                }
+
+                sidebar.classList.add('odoo-sidebar--open');
+                backdrop.hidden = false;
+                requestAnimationFrame(() => backdrop.classList.add('is-visible'));
+                toggle.setAttribute('aria-expanded', 'true');
+                document.addEventListener('keydown', handleEscape);
+            };
+
+            const closeSidebar = (force = false) => {
+                if (!force && !shouldUseOverlay()) {
+                    return;
+                }
+
+                sidebar.classList.remove('odoo-sidebar--open');
+                backdrop.classList.remove('is-visible');
+                toggle.setAttribute('aria-expanded', 'false');
+                const transitionFallback = window.setTimeout(onTransitionEnd, 300);
+                backdrop.addEventListener('transitionend', () => {
+                    window.clearTimeout(transitionFallback);
+                    onTransitionEnd();
+                }, { once: true });
+                document.removeEventListener('keydown', handleEscape);
+            };
+
+            const handleEscape = (event) => {
+                if (event.key === 'Escape') {
+                    closeSidebar();
+                }
+            };
+
+            toggle.addEventListener('click', (event) => {
+                event.preventDefault();
+                if (shouldUseOverlay()) {
+                    if (sidebar.classList.contains('odoo-sidebar--open')) {
+                        closeSidebar();
+                    } else {
+                        openSidebar();
+                    }
+                }
+            });
+
+            backdrop.addEventListener('click', () => closeSidebar(true));
+            close?.addEventListener('click', () => closeSidebar(true));
+
+            window.addEventListener('resize', () => {
+                if (window.innerWidth >= 992) {
+                    closeSidebar(true);
+                    backdrop.hidden = true;
+                }
+            });
+        })();
+    </script>
     @await RenderSectionAsync("Scripts", required: false)
 </body>
 </html>

--- a/AccountingSystem/wwwroot/css/site.css
+++ b/AccountingSystem/wwwroot/css/site.css
@@ -9,12 +9,19 @@ html {
 }
 
 :root {
-  --primary-color: #355C93;
-  --secondary-color: #5E88CA;
+  --odoo-purple: #875a7b;
+  --odoo-purple-dark: #6f4864;
+  --odoo-muted: #f4f5f7;
+  --odoo-text: #2e2e2e;
+  --odoo-border: #e4e6eb;
 }
 
-.btn:focus, .btn:active:focus, .btn-link.nav-link:focus, .form-control:focus, .form-check-input:focus {
-  box-shadow: 0 0 0 0.1rem white, 0 0 0 0.25rem var(--primary-color);
+.btn:focus,
+.btn:active:focus,
+.btn-link.nav-link:focus,
+.form-control:focus,
+.form-check-input:focus {
+  box-shadow: 0 0 0 0.1rem white, 0 0 0 0.25rem var(--odoo-purple);
 }
 
 html {
@@ -22,33 +29,275 @@ html {
   min-height: 100%;
 }
 
-body {
-  margin-bottom: 60px;
+.odoo-body {
+  background-color: var(--odoo-muted);
+  color: var(--odoo-text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
-.navbar {
-  background-color: var(--primary-color) !important;
+.odoo-topbar {
+  background: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1.5rem;
+  position: sticky;
+  top: 0;
+  z-index: 1030;
 }
 
-.navbar .navbar-brand,
-.navbar .nav-link,
-.navbar-brand span {
-  color: #fff !important;
+.odoo-topbar__section {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
 }
 
-.navbar .nav-link:hover {
-  color: var(--secondary-color) !important;
+.odoo-topbar__section--center {
+  flex: 1;
+  justify-content: center;
 }
 
-.navbar-logo {
-  height: 40px;
+.odoo-topbar__section--right {
+  justify-content: flex-end;
+  gap: 0.5rem;
 }
 
-.form-floating > .form-control-plaintext::placeholder, .form-floating > .form-control::placeholder {
-  color: var(--bs-secondary-color);
-  text-align: end;
+.odoo-brand__logo {
+  height: 34px;
 }
 
-.form-floating > .form-control-plaintext:focus::placeholder, .form-floating > .form-control:focus::placeholder {
-  text-align: start;
+.odoo-brand__name {
+  font-weight: 700;
+  color: var(--odoo-purple);
+  font-size: 1.15rem;
+}
+
+.odoo-icon-button {
+  color: var(--odoo-text);
+  font-size: 1.2rem;
+  padding: 0.25rem 0.5rem;
+}
+
+.odoo-icon-button:hover,
+.odoo-icon-button:focus {
+  color: var(--odoo-purple);
+  text-decoration: none;
+}
+
+.odoo-global-search {
+  background: var(--odoo-muted);
+  border-radius: 2rem;
+  padding: 0.35rem 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: min(520px, 100%);
+}
+
+.odoo-global-search .form-control {
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+  padding: 0;
+}
+
+.odoo-user {
+  color: var(--odoo-text);
+  gap: 0.5rem;
+}
+
+.odoo-user__avatar {
+  background-color: var(--odoo-purple);
+  color: #fff;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+}
+
+.odoo-subheader {
+  background: linear-gradient(90deg, var(--odoo-purple) 0%, var(--odoo-purple-dark) 100%);
+  color: #fff;
+  padding: 0.75rem 1.5rem;
+}
+
+.odoo-subheader__content {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.odoo-subheader__title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.odoo-subheader__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.odoo-subheader .btn-outline-secondary {
+  border-color: #fff;
+  color: #fff;
+}
+
+.odoo-subheader .btn-outline-secondary:hover,
+.odoo-subheader .btn-outline-secondary:focus {
+  background-color: rgba(255, 255, 255, 0.15);
+  border-color: #fff;
+}
+
+.odoo-subheader .btn-primary {
+  background-color: #fff;
+  color: var(--odoo-purple);
+  border-color: #fff;
+}
+
+.odoo-subheader .btn-primary:hover,
+.odoo-subheader .btn-primary:focus {
+  background-color: rgba(255, 255, 255, 0.9);
+  color: var(--odoo-purple);
+}
+
+.odoo-main {
+  flex: 1;
+  padding: 1rem 1.5rem 2rem;
+}
+
+.odoo-sidebar {
+  background: #fff;
+  border-radius: 1rem;
+  border: 1px solid var(--odoo-border);
+  padding: 1.5rem 1rem;
+  min-width: 220px;
+  max-width: 240px;
+  height: fit-content;
+}
+
+.odoo-sidebar__header button {
+  border-radius: 50%;
+}
+
+.odoo-sidebar .nav-link {
+  color: var(--odoo-text);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+}
+
+.odoo-sidebar .nav-link:hover,
+.odoo-sidebar .nav-link:focus {
+  background-color: var(--odoo-muted);
+  color: var(--odoo-purple);
+}
+
+.odoo-content-wrapper {
+  padding-left: 1.5rem;
+}
+
+.odoo-main__content {
+  background: #fff;
+  border-radius: 1rem;
+  border: 1px solid var(--odoo-border);
+  padding: 1.5rem;
+  min-height: calc(100vh - 220px);
+  box-shadow: 0 8px 20px rgba(135, 90, 123, 0.08);
+}
+
+.odoo-footer {
+  background: #fff;
+  padding: 0.75rem 1.5rem;
+  color: var(--odoo-text);
+}
+
+.odoo-sidebar-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  opacity: 0;
+  transition: opacity 0.25s ease;
+  z-index: 1025;
+}
+
+.odoo-sidebar-backdrop.is-visible {
+  opacity: 1;
+}
+
+@media (max-width: 991.98px) {
+  .odoo-sidebar {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    max-width: 280px;
+    width: calc(100% - 3rem);
+    border-radius: 0 1rem 1rem 0;
+    z-index: 1030;
+    overflow-y: auto;
+    box-shadow: 4px 0 20px rgba(0, 0, 0, 0.1);
+  }
+
+  .odoo-content-wrapper {
+    padding-left: 0;
+    margin-top: 1rem;
+  }
+
+  .odoo-sidebar--open {
+    transform: translateX(0);
+  }
+}
+
+@media (max-width: 767.98px) {
+  .odoo-topbar {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+  }
+
+  .odoo-topbar__section--center {
+    order: 3;
+  }
+
+  .odoo-topbar__section--right {
+    order: 2;
+    justify-content: space-between;
+  }
+
+  .odoo-topbar__section--left {
+    order: 1;
+    justify-content: space-between;
+  }
+
+  .odoo-subheader__content {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .odoo-subheader__actions {
+    justify-content: space-between;
+  }
+
+  .odoo-main {
+    padding: 1rem;
+  }
+
+  .odoo-sidebar-backdrop {
+    display: block;
+  }
 }


### PR DESCRIPTION
## Summary
- redesign the shared layout to introduce an Odoo-inspired top bar, subheader, and sidebar navigation experience
- add dropdowns, quick actions, and responsive sidebar scripting for a richer UX on mobile and desktop
- refresh the global stylesheet with Odoo-like colors, typography, and layout treatments to match the new structure

## Testing
- `dotnet build` *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9a79f5b80833395bba3e7742d17e5