### PR TITLE
Expose journal entry references across vouchers and reports

### DIFF
--- a/AccountingSystem/Controllers/AccountManagementController.cs
+++ b/AccountingSystem/Controllers/AccountManagementController.cs
@@ -1259,7 +1259,14 @@ namespace Roadfn.Controllers
                     lines.Add(PayCashAccountsDriverAttxn);
                     #endregion
 
-                    await _journalEntryService.CreateJournalEntryAsync(DateTime.Now, "DriverInvoice_" + driverPaymentHeader.Id, Accbrn.Id, user.Id, lines, JournalEntryStatus.Posted);
+                    await _journalEntryService.CreateJournalEntryAsync(
+                        DateTime.Now,
+                        "DriverInvoice_" + driverPaymentHeader.Id,
+                        Accbrn.Id,
+                        user.Id,
+                        lines,
+                        JournalEntryStatus.Posted,
+                        reference: $"DriverInvoice:{driverPaymentHeader.Id}");
 
                 }
 
@@ -1451,7 +1458,14 @@ namespace Roadfn.Controllers
                     CustomerAccounttxn.Description = sh.ShipmentTrackingNo;
                     lines.Add(CustomerAccounttxn);
                     #endregion
-                    await _journalEntryService.CreateJournalEntryAsync(DateTime.Now, "Business_" + bisnessUserPaymentHeader.Id, Accbrn.Id, user.Id, lines, JournalEntryStatus.Posted);
+                    await _journalEntryService.CreateJournalEntryAsync(
+                        DateTime.Now,
+                        "Business_" + bisnessUserPaymentHeader.Id,
+                        Accbrn.Id,
+                        user.Id,
+                        lines,
+                        JournalEntryStatus.Posted,
+                        reference: $"BusinessInvoice:{bisnessUserPaymentHeader.Id}");
 
                 }
 

--- a/AccountingSystem/Controllers/AssetExpensesController.cs
+++ b/AccountingSystem/Controllers/AssetExpensesController.cs
@@ -169,6 +169,7 @@ namespace AccountingSystem.Controllers
             };
 
             _context.AssetExpenses.Add(assetExpense);
+            await _context.SaveChangesAsync();
 
             var lines = new List<JournalEntryLine>
             {
@@ -186,15 +187,16 @@ namespace AccountingSystem.Controllers
                 }
             }
 
+            var reference = $"ASSETEXP:{assetExpense.Id}";
+
             await _journalEntryService.CreateJournalEntryAsync(
                 assetExpense.Date,
                 assetExpense.Notes == null ? "مصروف أصل" : "مصروف أصل" + Environment.NewLine + assetExpense.Notes,
                 asset!.BranchId,
                 user.Id,
                 lines,
-                JournalEntryStatus.Posted);
-
-            await _context.SaveChangesAsync();
+                JournalEntryStatus.Posted,
+                reference: reference);
 
             return RedirectToAction(nameof(Index));
         }

--- a/AccountingSystem/Controllers/AssetsController.cs
+++ b/AccountingSystem/Controllers/AssetsController.cs
@@ -174,13 +174,18 @@ namespace AccountingSystem.Controllers
                         description += Environment.NewLine + asset.Notes;
                     }
 
+                    var reference = !string.IsNullOrWhiteSpace(asset.AssetNumber)
+                        ? $"ASSET:{asset.AssetNumber}"
+                        : $"ASSET:{asset.Id}";
+
                     await _journalEntryService.CreateJournalEntryAsync(
                         DateTime.Now,
                         description,
                         asset.BranchId,
                         user.Id,
                         lines,
-                        JournalEntryStatus.Posted);
+                        JournalEntryStatus.Posted,
+                        reference: reference);
                 }
 
                 await transaction.CommitAsync();

--- a/AccountingSystem/Controllers/DisbursementVouchersController.cs
+++ b/AccountingSystem/Controllers/DisbursementVouchersController.cs
@@ -85,6 +85,7 @@ namespace AccountingSystem.Controllers
 
             model.CreatedById = user.Id;
             _context.DisbursementVouchers.Add(model);
+            await _context.SaveChangesAsync();
 
             var lines = new List<JournalEntryLine>
             {
@@ -92,13 +93,16 @@ namespace AccountingSystem.Controllers
                 new JournalEntryLine { AccountId = user.PaymentAccountId.Value, CreditAmount = model.Amount }
             };
 
+            var reference = $"DSBV:{model.Id}";
+
             await _journalEntryService.CreateJournalEntryAsync(
                 model.Date,
                 model.Notes ?? "سند صرف",
                 user.PaymentBranchId.Value,
                 user.Id,
                 lines,
-                JournalEntryStatus.Posted);
+                JournalEntryStatus.Posted,
+                reference: reference);
 
             return RedirectToAction(nameof(Index));
         }

--- a/AccountingSystem/Controllers/PaymentVouchersController.cs
+++ b/AccountingSystem/Controllers/PaymentVouchersController.cs
@@ -132,6 +132,7 @@ namespace AccountingSystem.Controllers
 
             model.CreatedById = user.Id;
             _context.PaymentVouchers.Add(model);
+            await _context.SaveChangesAsync();
 
             var lines = new List<JournalEntryLine>
             {
@@ -145,13 +146,16 @@ namespace AccountingSystem.Controllers
                 lines.Add(new JournalEntryLine { AccountId = user.PaymentAccountId.Value, CreditAmount = model.Amount });
             }
 
+            var reference = $"PAYV:{model.Id}";
+
             await _journalEntryService.CreateJournalEntryAsync(
                 model.Date,
                 model.Notes == null ? "سند دفع" : "سند دفع" + Environment.NewLine + model.Notes,
                 user.PaymentBranchId.Value,
                 user.Id,
                 lines,
-                JournalEntryStatus.Posted);
+                JournalEntryStatus.Posted,
+                reference: reference);
 
             return RedirectToAction(nameof(Index));
         }

--- a/AccountingSystem/Controllers/ReceiptVouchersController.cs
+++ b/AccountingSystem/Controllers/ReceiptVouchersController.cs
@@ -83,6 +83,7 @@ namespace AccountingSystem.Controllers
 
             model.CreatedById = user.Id;
             _context.ReceiptVouchers.Add(model);
+            await _context.SaveChangesAsync();
 
             var lines = new List<JournalEntryLine>
             {
@@ -90,13 +91,16 @@ namespace AccountingSystem.Controllers
                 new JournalEntryLine { AccountId = model.AccountId, CreditAmount = model.Amount }
             };
 
+            var reference = $"RCV:{model.Id}";
+
             await _journalEntryService.CreateJournalEntryAsync(
                 model.Date,
                 model.Notes ?? "سند قبض",
                 user.PaymentBranchId.Value,
                 user.Id,
                 lines,
-                JournalEntryStatus.Posted);
+                JournalEntryStatus.Posted,
+                reference: reference);
 
             return RedirectToAction(nameof(Index));
         }

--- a/AccountingSystem/Controllers/ReportsController.cs
+++ b/AccountingSystem/Controllers/ReportsController.cs
@@ -1876,6 +1876,8 @@ namespace AccountingSystem.Controllers
                         {
                             Date = line.JournalEntry.Date,
                             JournalEntryNumber = line.JournalEntry.Number,
+                            Reference = line.JournalEntry.Reference ?? string.Empty,
+                            MovementType = line.JournalEntry.Description,
                             Description = line.Description ?? string.Empty,
                             DebitAmount = line.DebitAmount,
                             CreditAmount = line.CreditAmount,

--- a/AccountingSystem/Services/JournalEntryService.cs
+++ b/AccountingSystem/Services/JournalEntryService.cs
@@ -56,6 +56,7 @@ namespace AccountingSystem.Services
                 {
                     AccountId = line.AccountId,
                     Description = string.IsNullOrWhiteSpace(line.Description) ? entry.Description : line.Description,
+                    Reference = line.Reference,
                     DebitAmount = line.DebitAmount,
                     CreditAmount = line.CreditAmount
                 });

--- a/AccountingSystem/ViewModels/SimpleViewModels.cs
+++ b/AccountingSystem/ViewModels/SimpleViewModels.cs
@@ -318,6 +318,8 @@ namespace AccountingSystem.ViewModels
     {
         public DateTime Date { get; set; }
         public string JournalEntryNumber { get; set; } = string.Empty;
+        public string Reference { get; set; } = string.Empty;
+        public string MovementType { get; set; } = string.Empty;
         public string Description { get; set; } = string.Empty;
         public decimal DebitAmount { get; set; }
         public decimal CreditAmount { get; set; }

--- a/AccountingSystem/Views/JournalEntries/Index.cshtml
+++ b/AccountingSystem/Views/JournalEntries/Index.cshtml
@@ -74,6 +74,7 @@
                                 <option value="BranchName">حسب الفرع</option>
                                 <option value="StatusDisplay">حسب الحالة</option>
                                 <option value="DateGroup">حسب الشهر</option>
+                                <option value="Reference" selected>حسب المرجع</option>
                             </select>
                         </div>
                         <div class="col-sm-6 col-lg-3 d-flex">
@@ -157,7 +158,7 @@
             var trackedRequestTypes = ['paging', 'sorting', 'filtering', 'searching', 'grouping', 'ungrouping', 'refresh'];
 
             grid.pageSettings = { pageSize: 10, pageSizes: [10, 25, 50, 100, 'All'] };
-            grid.groupSettings = { showDropArea: false };
+            grid.groupSettings = { showDropArea: false, columns: ['Reference'] };
 
             grid.actionBegin = function (args) {
                 if (trackedRequestTypes.indexOf(args.requestType) > -1) {
@@ -225,12 +226,13 @@
                     document.getElementById('toDate').value = '';
                     document.getElementById('branchFilter').selectedIndex = 0;
                     document.getElementById('statusFilter').selectedIndex = 0;
-                    document.getElementById('groupBy').value = '';
+                    document.getElementById('groupBy').value = 'Reference';
 
                     grid.clearFiltering();
                     grid.clearSorting();
                     grid.searchSettings.key = '';
                     grid.clearGrouping();
+                    grid.groupColumn('Reference');
                     grid.pageSettings.currentPage = 1;
                     reloadGrid();
                 });
@@ -238,6 +240,10 @@
 
             var groupSelect = document.getElementById('groupBy');
             if (groupSelect) {
+                if (groupSelect.value) {
+                    grid.clearGrouping();
+                    grid.groupColumn(groupSelect.value);
+                }
                 groupSelect.addEventListener('change', function (event) {
                     grid.clearGrouping();
                     var value = event.target.value;

--- a/AccountingSystem/Views/Reports/AccountStatement.cshtml
+++ b/AccountingSystem/Views/Reports/AccountStatement.cshtml
@@ -90,6 +90,8 @@
                                     <tr>
                                         <th>التاريخ</th>
                                         <th>رقم القيد</th>
+                                        <th>المرجع</th>
+                                        <th>نوع الحركة</th>
                                         <th>البيان</th>
                                         <th>مدين (@Model.CurrencyCode)</th>
                                         <th>دائن (@Model.CurrencyCode)</th>
@@ -104,6 +106,8 @@
                                             <tr>
                                                 <td>@transaction.Date.ToString("yyyy/MM/dd")</td>
                                                 <td>@transaction.JournalEntryNumber</td>
+                                                <td>@(string.IsNullOrWhiteSpace(transaction.Reference) ? "-" : transaction.Reference)</td>
+                                                <td>@transaction.MovementType</td>
                                                 <td>@transaction.Description</td>
                                                 <td class="text-end">
                                                     @if (transaction.DebitAmount > 0)
@@ -137,7 +141,7 @@
                                     else
                                     {
                                         <tr>
-                                            <td colspan="6" class="text-center text-muted py-4">
+                                            <td colspan="8" class="text-center text-muted py-4">
                                                 <i class="fas fa-inbox fa-2x mb-2"></i>
                                                 <br>
                                                 لا توجد حركات في الفترة المحددة


### PR DESCRIPTION
## Summary
- propagate reference values when creating journal entries from asset expenses, vouchers, and payment workflows
- expose journal entry reference and movement type information in the account statement and copy line references when saving
- default the journal entries list to group by reference for easier review

## Testing
- `dotnet build` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68daa73797548333bf6d88a23b093581