### PR TITLE
Add print-friendly account statement with entry links

### DIFF
--- a/AccountingSystem/ViewModels/SimpleViewModels.cs
+++ b/AccountingSystem/ViewModels/SimpleViewModels.cs
@@ -317,6 +317,7 @@ namespace AccountingSystem.ViewModels
     public class AccountTransactionViewModel
     {
         public DateTime Date { get; set; }
+        public int JournalEntryId { get; set; }
         public string JournalEntryNumber { get; set; } = string.Empty;
         public string Reference { get; set; } = string.Empty;
         public string MovementType { get; set; } = string.Empty;

--- a/AccountingSystem/Views/Reports/AccountStatement.cshtml
+++ b/AccountingSystem/Views/Reports/AccountStatement.cshtml
@@ -28,7 +28,7 @@
                                 {
                                     @foreach (var account in Model.Accounts)
                                     {
-                                        <option value="@account.Value">@account.Text</option>
+                                        <option value="@account.Value" @(account.Selected ? "selected" : string.Empty)>@account.Text</option>
                                     }
                                 }
                             </select>
@@ -41,18 +41,18 @@
                                 {
                                     @foreach (var branch in Model.Branches)
                                     {
-                                        <option value="@branch.Value">@branch.Text</option>
+                                        <option value="@branch.Value" @(branch.Selected ? "selected" : string.Empty)>@branch.Text</option>
                                     }
                                 }
                             </select>
                         </div>
                         <div class="col-md-2">
                             <label for="fromDate" class="form-label">من تاريخ:</label>
-                            <input type="date" name="fromDate" id="fromDate" class="form-control" value="@DateTime.Now.AddMonths(-1).ToString("yyyy-MM-dd")" />
+                            <input type="date" name="fromDate" id="fromDate" class="form-control" value="@(Model != null ? Model.FromDate.ToString("yyyy-MM-dd") : DateTime.Now.AddMonths(-1).ToString("yyyy-MM-dd"))" />
                         </div>
                         <div class="col-md-2">
                             <label for="toDate" class="form-label">إلى تاريخ:</label>
-                            <input type="date" name="toDate" id="toDate" class="form-control" value="@DateTime.Now.ToString("yyyy-MM-dd")" />
+                            <input type="date" name="toDate" id="toDate" class="form-control" value="@(Model != null ? Model.ToDate.ToString("yyyy-MM-dd") : DateTime.Now.ToString("yyyy-MM-dd"))" />
                         </div>
                         <div class="col-md-3">
                             <label class="form-label">&nbsp;</label>
@@ -83,6 +83,13 @@
                             </div>
                         </div>
 
+                        <div class="d-flex justify-content-end mb-3">
+                            <a class="btn btn-outline-primary" target="_blank" href="@Url.Action("PrintAccountStatement", "Reports", new { accountId = Model.AccountId, branchId = Model.BranchId, fromDate = Model.FromDate.ToString("yyyy-MM-dd"), toDate = Model.ToDate.ToString("yyyy-MM-dd") })">
+                                <i class="fas fa-print me-1"></i>
+                                طباعة A4
+                            </a>
+                        </div>
+
                         <!-- جدول الحركات -->
                         <div class="table-responsive">
                             <table class="table table-striped table-hover">
@@ -105,8 +112,17 @@
                                         {
                                             <tr>
                                                 <td>@transaction.Date.ToString("yyyy/MM/dd")</td>
-                                                <td>@transaction.JournalEntryNumber</td>
-                                                <td>@(string.IsNullOrWhiteSpace(transaction.Reference) ? "-" : transaction.Reference)</td>
+                                                <td>
+                                                    <a href="@Url.Action("Details", "JournalEntries", new { id = transaction.JournalEntryId })" class="text-decoration-none" target="_blank">
+                                                        @transaction.JournalEntryNumber
+                                                    </a>
+                                                </td>
+                                                <td>
+                                                    <a href="@Url.Action("Details", "JournalEntries", new { id = transaction.JournalEntryId })" class="btn btn-sm btn-outline-secondary" target="_blank">
+                                                        <i class="fas fa-link me-1"></i>
+                                                        @(string.IsNullOrWhiteSpace(transaction.Reference) ? "عرض القيد" : transaction.Reference)
+                                                    </a>
+                                                </td>
                                                 <td>@transaction.MovementType</td>
                                                 <td>@transaction.Description</td>
                                                 <td class="text-end">

--- a/AccountingSystem/Views/Reports/PrintAccountStatement.cshtml
+++ b/AccountingSystem/Views/Reports/PrintAccountStatement.cshtml
@@ -1,0 +1,209 @@
+@model AccountingSystem.ViewModels.AccountStatementViewModel
+@{
+    Layout = null;
+    var printDate = DateTime.Now;
+}
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+    <meta charset="utf-8" />
+    <title>طباعة كشف الحساب</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.rtl.min.css" integrity="sha384-5A6DwZ0pniS3pSkeCZMt2rt7NmBGG99nmCaTKty+PBkO5OVwOB1p5MNDoAuCEVsD" crossorigin="anonymous">
+    <style>
+        body {
+            font-family: 'Tajawal', 'Segoe UI', sans-serif;
+            background-color: #f8f9fa;
+            color: #212529;
+        }
+        .print-container {
+            width: 210mm;
+            min-height: 297mm;
+            margin: 0 auto;
+            padding: 25mm 20mm 20mm 20mm;
+            background-color: #fff;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.08);
+        }
+        .document-header {
+            border-bottom: 3px solid #0d6efd;
+            margin-bottom: 20px;
+            padding-bottom: 10px;
+        }
+        .document-header h1 {
+            font-size: 28px;
+            margin-bottom: 0;
+        }
+        .document-meta {
+            font-size: 14px;
+            color: #6c757d;
+        }
+        .summary-box {
+            border: 1px solid #dee2e6;
+            border-radius: 0.5rem;
+            padding: 15px;
+            margin-bottom: 20px;
+        }
+        .summary-title {
+            font-weight: 600;
+            color: #0d6efd;
+        }
+        table thead {
+            background-color: #0d6efd;
+            color: #fff;
+        }
+        table th, table td {
+            vertical-align: middle;
+            font-size: 13px;
+        }
+        .footer-signatures {
+            margin-top: 40px;
+        }
+        .signature-box {
+            border-top: 1px solid #adb5bd;
+            padding-top: 10px;
+            min-height: 60px;
+            font-size: 14px;
+        }
+        @media print {
+            body {
+                background-color: #fff;
+            }
+            .print-container {
+                box-shadow: none;
+                margin: 0;
+                width: auto;
+                min-height: auto;
+                padding: 10mm 10mm 10mm 10mm;
+            }
+            .no-print {
+                display: none !important;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="print-container">
+        <div class="no-print text-end mb-3">
+            <button class="btn btn-primary" onclick="window.print();"><i class="fas fa-print me-2"></i>طباعة</button>
+            <button class="btn btn-outline-secondary ms-2" onclick="window.close();">إغلاق</button>
+        </div>
+        <div class="document-header text-center">
+            <h1>كشف حساب</h1>
+            <p class="document-meta mb-0">تاريخ الطباعة: @printDate.ToString("yyyy/MM/dd HH:mm")</p>
+        </div>
+        <div class="row mb-4">
+            <div class="col-6">
+                <div class="summary-box">
+                    <div class="summary-title">بيانات الحساب</div>
+                    <div><strong>الحساب:</strong> @Model.AccountName</div>
+                    <div><strong>رقم الحساب:</strong> @Model.AccountCode</div>
+                    <div><strong>الفترة:</strong> @Model.FromDate.ToString("yyyy/MM/dd") - @Model.ToDate.ToString("yyyy/MM/dd")</div>
+                    @if (Model.BranchId.HasValue)
+                    {
+                        var selectedBranch = Model.Branches.FirstOrDefault(b => b.Value == Model.BranchId.Value.ToString());
+                        if (selectedBranch != null)
+                        {
+                            <div><strong>الفرع:</strong> @selectedBranch.Text</div>
+                        }
+                    }
+                </div>
+            </div>
+            <div class="col-6">
+                <div class="summary-box">
+                    <div class="summary-title">أرصدة الحساب</div>
+                    <div><strong>الرصيد الافتتاحي:</strong> @Model.OpeningBalance.ToString("N2") @Model.CurrencyCode</div>
+                    <div><strong>الرصيد الافتتاحي (العملة الأساسية):</strong> @Model.OpeningBalanceBase.ToString("N2") @Model.BaseCurrencyCode</div>
+                    <div><strong>الرصيد الختامي:</strong> @Model.ClosingBalance.ToString("N2") @Model.CurrencyCode</div>
+                    <div><strong>الرصيد الختامي (العملة الأساسية):</strong> @Model.ClosingBalanceBase.ToString("N2") @Model.BaseCurrencyCode</div>
+                </div>
+            </div>
+        </div>
+        <div class="row mb-4">
+            <div class="col-4">
+                <div class="summary-box text-center">
+                    <div class="summary-title">إجمالي المدين</div>
+                    <div class="fw-bold fs-5">@Model.TotalDebit.ToString("N2") @Model.CurrencyCode</div>
+                    <div class="text-muted">@Model.TotalDebitBase.ToString("N2") @Model.BaseCurrencyCode</div>
+                </div>
+            </div>
+            <div class="col-4">
+                <div class="summary-box text-center">
+                    <div class="summary-title">إجمالي الدائن</div>
+                    <div class="fw-bold fs-5">@Model.TotalCredit.ToString("N2") @Model.CurrencyCode</div>
+                    <div class="text-muted">@Model.TotalCreditBase.ToString("N2") @Model.BaseCurrencyCode</div>
+                </div>
+            </div>
+            <div class="col-4">
+                <div class="summary-box text-center">
+                    <div class="summary-title">صافي الحركة</div>
+                    <div class="fw-bold fs-5">@((Model.TotalDebit - Model.TotalCredit).ToString("N2")) @Model.CurrencyCode</div>
+                    <div class="text-muted">@((Model.TotalDebitBase - Model.TotalCreditBase).ToString("N2")) @Model.BaseCurrencyCode</div>
+                </div>
+            </div>
+        </div>
+        <table class="table table-bordered table-striped align-middle">
+            <thead>
+                <tr>
+                    <th>التاريخ</th>
+                    <th>رقم القيد</th>
+                    <th>المرجع</th>
+                    <th>نوع الحركة</th>
+                    <th>البيان</th>
+                    <th class="text-end">مدين (@Model.CurrencyCode)</th>
+                    <th class="text-end">دائن (@Model.CurrencyCode)</th>
+                    <th class="text-end">الرصيد (@Model.CurrencyCode)</th>
+                </tr>
+            </thead>
+            <tbody>
+                @if (Model.Transactions != null && Model.Transactions.Any())
+                {
+                    foreach (var transaction in Model.Transactions)
+                    {
+                        <tr>
+                            <td>@transaction.Date.ToString("yyyy/MM/dd")</td>
+                            <td>@transaction.JournalEntryNumber</td>
+                            <td>@(string.IsNullOrWhiteSpace(transaction.Reference) ? "-" : transaction.Reference)</td>
+                            <td>@transaction.MovementType</td>
+                            <td>@transaction.Description</td>
+                            <td class="text-end">
+                                @(transaction.DebitAmount > 0 ? transaction.DebitAmount.ToString("N2") : "-")
+                                <div class="text-muted">@(transaction.DebitAmount > 0 ? transaction.DebitAmountBase.ToString("N2") + " " + Model.BaseCurrencyCode : "")</div>
+                            </td>
+                            <td class="text-end">
+                                @(transaction.CreditAmount > 0 ? transaction.CreditAmount.ToString("N2") : "-")
+                                <div class="text-muted">@(transaction.CreditAmount > 0 ? transaction.CreditAmountBase.ToString("N2") + " " + Model.BaseCurrencyCode : "")</div>
+                            </td>
+                            <td class="text-end">
+                                @transaction.RunningBalance.ToString("N2")
+                                <div class="text-muted">@transaction.RunningBalanceBase.ToString("N2") @Model.BaseCurrencyCode</div>
+                            </td>
+                        </tr>
+                    }
+                }
+                else
+                {
+                    <tr>
+                        <td colspan="8" class="text-center text-muted">لا توجد حركات في الفترة المحددة</td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+        <div class="footer-signatures row text-center">
+            <div class="col-4">
+                <div class="signature-box">المحاسب</div>
+            </div>
+            <div class="col-4">
+                <div class="signature-box">المدير المالي</div>
+            </div>
+            <div class="col-4">
+                <div class="signature-box">المدير العام</div>
+            </div>
+        </div>
+    </div>
+    <script src="https://kit.fontawesome.com/a2d9d6c6f4.js" crossorigin="anonymous"></script>
+    <script>
+        window.addEventListener('load', function () {
+            setTimeout(function () { window.print(); }, 300);
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- refactor account statement report builder logic and expose journal entry ids
- make reference and entry number link to the original journal entry from the report
- add an A4 styled printable account statement view with totals and metadata

## Testing
- `dotnet build AccountingSystem/AccountingSystem.sln` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68daaebc11d083338b5dd14d93c95e6d