### PR TITLE
Add report for user cash transactions with journal entry links

### DIFF
--- a/AccountingSystem/ViewModels/UserCashTransactionReportViewModel.cs
+++ b/AccountingSystem/ViewModels/UserCashTransactionReportViewModel.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Mvc.Rendering;
+using System;
+using System.Collections.Generic;
+
+namespace AccountingSystem.ViewModels
+{
+    public class UserCashTransactionReportViewModel
+    {
+        public string SelectedType { get; set; } = "all";
+        public int? SelectedAccountId { get; set; }
+        public List<SelectListItem> Accounts { get; set; } = new();
+        public List<UserCashTransactionReportItem> Items { get; set; } = new();
+    }
+
+    public class UserCashTransactionReportItem
+    {
+        public DateTime Date { get; set; }
+        public CashTransactionType Type { get; set; }
+        public int? AccountId { get; set; }
+        public string AccountName { get; set; } = string.Empty;
+        public decimal Amount { get; set; }
+        public string Currency { get; set; } = string.Empty;
+        public string Reference { get; set; } = string.Empty;
+        public string? Notes { get; set; }
+        public int? JournalEntryId { get; set; }
+        public string? JournalEntryNumber { get; set; }
+
+        public string TypeDisplay => Type switch
+        {
+            CashTransactionType.Payment => "سند دفع",
+            CashTransactionType.Receipt => "سند قبض",
+            _ => "غير معروف"
+        };
+    }
+
+    public enum CashTransactionType
+    {
+        Receipt,
+        Payment
+    }
+}

--- a/AccountingSystem/Views/Reports/Index.cshtml
+++ b/AccountingSystem/Views/Reports/Index.cshtml
@@ -134,6 +134,19 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="col-md-4 mb-3">
+                            <div class="card h-100 border-dark">
+                                <div class="card-body text-center">
+                                    <i class="fas fa-wallet fa-3x text-dark mb-3"></i>
+                                    <h5 class="card-title">حركات المستخدم النقدية</h5>
+                                    <p class="card-text">استعرض سندات القبض والدفع حسب الحساب والنوع مع الوصول للقيد المحاسبي المرتبط</p>
+                                    <a asp-action="UserCashTransactions" class="btn btn-dark">
+                                        <i class="fas fa-eye me-1"></i>
+                                        عرض التقرير
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/AccountingSystem/Views/Reports/UserCashTransactions.cshtml
+++ b/AccountingSystem/Views/Reports/UserCashTransactions.cshtml
@@ -1,0 +1,104 @@
+@model AccountingSystem.ViewModels.UserCashTransactionReportViewModel
+@{
+    ViewData["Title"] = "تقرير تحركات المستخدم النقدية";
+    Layout = "~/Views/Shared/_AccountingLayout.cshtml";
+}
+
+<div class="container-fluid">
+    <div class="card">
+        <div class="card-header bg-primary text-white">
+            <h5 class="mb-0">
+                <i class="fas fa-wallet me-2"></i>
+                تقرير الحركات حسب نوع القيد وحساب المستخدم
+            </h5>
+        </div>
+        <div class="card-body">
+            <form method="get" class="row g-3">
+                <div class="col-md-4">
+                    <label for="type" class="form-label">نوع الحركة</label>
+                    <select id="type" name="type" class="form-select">
+                        <option value="all" @(Model.SelectedType == "all" ? "selected" : string.Empty)>جميع الأنواع</option>
+                        <option value="receipt" @(Model.SelectedType == "receipt" ? "selected" : string.Empty)>سندات القبض</option>
+                        <option value="payment" @(Model.SelectedType == "payment" ? "selected" : string.Empty)>سندات الدفع</option>
+                    </select>
+                </div>
+                <div class="col-md-4">
+                    <label for="accountId" class="form-label">الحساب</label>
+                    <select id="accountId" name="accountId" class="form-select">
+                        <option value="">جميع الحسابات</option>
+                        @foreach (var account in Model.Accounts)
+                        {
+                            <option value="@account.Value" @(account.Selected ? "selected" : string.Empty)>@account.Text</option>
+                        }
+                    </select>
+                </div>
+                <div class="col-md-4 d-flex align-items-end">
+                    <button type="submit" class="btn btn-primary w-100">
+                        <i class="fas fa-search me-1"></i>
+                        عرض النتائج
+                    </button>
+                </div>
+            </form>
+
+            <div class="table-responsive mt-4">
+                <table class="table table-striped table-hover align-middle">
+                    <thead class="table-dark">
+                        <tr>
+                            <th>التاريخ</th>
+                            <th>نوع القيد</th>
+                            <th>الحساب</th>
+                            <th>المبلغ</th>
+                            <th>العملة</th>
+                            <th>المرجع</th>
+                            <th>القيد المحاسبي</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @if (Model.Items.Count == 0)
+                        {
+                            <tr>
+                                <td colspan="7" class="text-center text-muted py-4">
+                                    لا توجد حركات مطابقة لخيارات البحث الحالية.
+                                </td>
+                            </tr>
+                        }
+                        else
+                        {
+                            foreach (var item in Model.Items)
+                            {
+                                <tr>
+                                    <td>@item.Date.ToString("yyyy-MM-dd")</td>
+                                    <td>@item.TypeDisplay</td>
+                                    <td>@item.AccountName</td>
+                                    <td>@item.Amount.ToString("N2")</td>
+                                    <td>@item.Currency</td>
+                                    <td>@item.Reference</td>
+                                    <td>
+                                        @if (item.JournalEntryId.HasValue)
+                                        {
+                                            <div class="d-flex flex-column">
+                                                <span class="fw-semibold">@item.JournalEntryNumber</span>
+                                                <a asp-controller="JournalEntries"
+                                                   asp-action="Details"
+                                                   asp-route-id="@item.JournalEntryId.Value"
+                                                   asp-require-permission="journal.view"
+                                                   class="btn btn-sm btn-outline-primary mt-2">
+                                                    <i class="fas fa-book-open me-1"></i>
+                                                    عرض القيد
+                                                </a>
+                                            </div>
+                                        }
+                                        else
+                                        {
+                                            <span class="text-muted">لا يوجد قيد مرتبط</span>
+                                        }
+                                    </td>
+                                </tr>
+                            }
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add a user cash transactions report that filters by entry type and account and links back to journal entries
- introduce supporting view model and UI card entry in the reports index for quick access

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dad08491048333bec4ec89b331107a