### PR TITLE
Fix shared-type conflict in ApplicationDbContext model snapshot

### DIFF
--- a/AccountingSystem/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/AccountingSystem/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -398,7 +398,7 @@ namespace AccountingSystem.Migrations
                     b.ToTable("CashBoxClosures");
                 });
 
-            modelBuilder.Entity<Employee>(b =>
+            modelBuilder.Entity("AccountingSystem.Models.Employee", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -2072,25 +2072,25 @@ namespace AccountingSystem.Migrations
                     b.Navigation("Branch");
                 });
 
-            modelBuilder.Entity<Employee>(b =>
+            modelBuilder.Entity("AccountingSystem.Models.Employee", b =>
                 {
-                    b.HasOne<Account>(e => e.Account)
+                    b.HasOne("AccountingSystem.Models.Account", "Account")
                         .WithMany()
                         .HasForeignKey("AccountId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
-                    b.HasOne<Branch>(e => e.Branch)
-                        .WithMany(b => b.Employees)
+                    b.HasOne("AccountingSystem.Models.Branch", "Branch")
+                        .WithMany("Employees")
                         .HasForeignKey("BranchId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
-                    b.Navigation(e => e.Account);
+                    b.Navigation("Account");
 
-                    b.Navigation(e => e.Branch);
+                    b.Navigation("Branch");
 
-                    b.Navigation(e => e.PayrollLines);
+                    b.Navigation("PayrollLines");
                 });
 
             modelBuilder.Entity("AccountingSystem.Models.AssetExpense", b =>


### PR DESCRIPTION
## Summary
- align the Employee entity configuration in ApplicationDbContextModelSnapshot with string-based entity mapping to prevent EF shared-type conflicts during migrations

## Testing
- dotnet ef database update --context ApplicationDbContext *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc03674bc88333b41be795215e4980