### PR TITLE
Fix payroll navigation configuration

### DIFF
--- a/AccountingSystem/Data/ApplicationDbContext.cs
+++ b/AccountingSystem/Data/ApplicationDbContext.cs
@@ -215,6 +215,11 @@ namespace AccountingSystem.Data
                     .WithMany()
                     .HasForeignKey(e => e.AccountId)
                     .OnDelete(DeleteBehavior.Restrict);
+
+                entity.HasMany(e => e.PayrollLines)
+                    .WithOne(l => l.Employee)
+                    .HasForeignKey(l => l.EmployeeId)
+                    .OnDelete(DeleteBehavior.Restrict);
             });
 
             builder.Entity<PayrollBatch>(entity =>

--- a/AccountingSystem/Models/Employee.cs
+++ b/AccountingSystem/Models/Employee.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AccountingSystem.Models
 {
@@ -42,6 +43,7 @@ namespace AccountingSystem.Models
 
         public virtual Account Account { get; set; } = null!;
 
+        [InverseProperty(nameof(PayrollBatchLine.Employee))]
         public virtual ICollection<PayrollBatchLine> PayrollLines { get; set; } = new List<PayrollBatchLine>();
     }
 }

--- a/AccountingSystem/Models/PayrollBatchLine.cs
+++ b/AccountingSystem/Models/PayrollBatchLine.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AccountingSystem.Models
 {
@@ -20,6 +21,7 @@ namespace AccountingSystem.Models
 
         public virtual PayrollBatch PayrollBatch { get; set; } = null!;
 
+        [InverseProperty(nameof(Employee.PayrollLines))]
         public virtual Employee Employee { get; set; } = null!;
 
         public virtual Branch Branch { get; set; } = null!;


### PR DESCRIPTION
## Summary
- ensure the Employee entity explicitly maps its payroll line navigation in the model builder
- add inverse property attributes to the Employee and PayrollBatchLine models for clarity

## Testing
- not run (environment does not have the .NET SDK)

------
https://chatgpt.com/codex/tasks/task_e_68dc05d4139c8333bfbbdf572b590311