### PR TITLE
Fix AccountType enum mapping in migrations snapshot

### DIFF
--- a/AccountingSystem/Migrations/20250928193221_asswttype.Designer.cs
+++ b/AccountingSystem/Migrations/20250928193221_asswttype.Designer.cs
@@ -34,7 +34,7 @@ namespace AccountingSystem.Migrations
 
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
-                    b.Property<int>("AccountType")
+                    b.Property<AccountType>("AccountType")
                         .HasColumnType("int");
 
                     b.Property<int?>("BranchId")

--- a/AccountingSystem/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/AccountingSystem/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -31,7 +31,7 @@ namespace AccountingSystem.Migrations
 
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
-                    b.Property<int>("AccountType")
+                    b.Property<AccountType>("AccountType")
                         .HasColumnType("int");
 
                     b.Property<int?>("BranchId")


### PR DESCRIPTION
## Summary
- update the ApplicationDbContext snapshot and the latest migration designer so that the Account entity's AccountType property is mapped using the enum type instead of int

## Testing
- Not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68dc0ad23b648333b16f32f9c408f5ad