### PR TITLE
Implement AJAX-loaded account trees across UI

### DIFF
--- a/AccountingSystem/Controllers/DashboardController.cs
+++ b/AccountingSystem/Controllers/DashboardController.cs
@@ -38,91 +38,9 @@ namespace AccountingSystem.Controllers
                 branchId = null;
             }
 
-            var allowedBranchIds = branchId.HasValue ? new List<int> { branchId.Value } : userBranchIds;
+            var treeData = await ComputeDashboardTreeAsync(userBranchIds, branchId, fromDate, toDate, currencyId);
 
-            var startDate = fromDate?.Date ?? DateTime.Today;
-            var endDate = toDate?.Date ?? DateTime.Today;
-            endDate = endDate.Date.AddDays(1).AddTicks(-1);
-
-            var accounts = await _context.Accounts
-                .Where(a => !allowedBranchIds.Any() || a.BranchId == null || allowedBranchIds.Contains(a.BranchId.Value))
-                .Include(a => a.JournalEntryLines)
-                    .ThenInclude(l => l.JournalEntry)
-                .Include(a => a.Currency)
-                .AsNoTracking()
-                .ToListAsync();
-
-            var baseCurrency = await _context.Currencies.FirstAsync(c => c.IsBase);
-            var selectedCurrency = currencyId.HasValue ? await _context.Currencies.FirstOrDefaultAsync(c => c.Id == currencyId.Value) : baseCurrency;
-            selectedCurrency ??= baseCurrency;
-
-            var accountBalances = accounts.ToDictionary(a => a.Id, a =>
-                a.OpeningBalance + a.JournalEntryLines
-                    .Where(l => l.JournalEntry.Date >= startDate && l.JournalEntry.Date <= endDate && allowedBranchIds.Contains(l.JournalEntry.BranchId))
-                    .Sum(l => l.DebitAmount - l.CreditAmount));
-
-            var cashBoxes = accounts
-                .Where(a => a.Code.StartsWith("1101"))
-                .Select(a => new CashBoxBalanceViewModel
-                {
-                    AccountName = a.NameAr,
-                    BranchName = a.Branch?.NameAr ?? string.Empty,
-                    Balance = accountBalances[a.Id],
-                    BalanceSelected = _currencyService.Convert(accountBalances[a.Id], a.Currency, selectedCurrency),
-                    BalanceBase = _currencyService.Convert(accountBalances[a.Id], a.Currency, baseCurrency)
-                })
-                .ToList();
-
-            var nodes = accounts.Select(a => new AccountTreeNodeViewModel
-            {
-                Id = a.Id,
-                Code = a.Code,
-                NameAr = a.NameAr,
-                AccountType = a.AccountType,
-                Nature = a.Nature,
-                CurrencyCode = a.Currency.Code,
-                OpeningBalance = a.OpeningBalance,
-                Balance = accountBalances[a.Id],
-                BalanceSelected = _currencyService.Convert(accountBalances[a.Id], a.Currency, selectedCurrency),
-                BalanceBase = _currencyService.Convert(accountBalances[a.Id], a.Currency, baseCurrency),
-                IsActive = a.IsActive,
-                CanPostTransactions = a.CanPostTransactions,
-                ParentId = a.ParentId,
-                Level = a.Level,
-                Children = new List<AccountTreeNodeViewModel>(),
-                HasChildren = false
-            }).ToDictionary(n => n.Id);
-
-            foreach (var node in nodes.Values)
-            {
-                if (node.ParentId.HasValue && nodes.TryGetValue(node.ParentId.Value, out var parent))
-                {
-                    parent.Children.Add(node);
-                    parent.HasChildren = true;
-                }
-            }
-
-            void ComputeBalances(AccountTreeNodeViewModel node)
-            {
-                foreach (var child in node.Children)
-                {
-                    ComputeBalances(child);
-                }
-                if (node.Children.Any())
-                {
-                    node.Balance = node.Children.Sum(c => c.Balance);
-                    node.BalanceSelected = node.Children.Sum(c => c.BalanceSelected);
-                    node.BalanceBase = node.Children.Sum(c => c.BalanceBase);
-                }
-            }
-
-            var rootNodes = nodes.Values.Where(n => n.ParentId == null).ToList();
-            foreach (var root in rootNodes)
-            {
-                ComputeBalances(root);
-            }
-
-            var accountTypeTrees = rootNodes
+            var accountTypeTrees = treeData.RootNodes
                 .GroupBy(n => n.AccountType)
                 .Select(g => new AccountTreeNodeViewModel
                 {
@@ -133,32 +51,38 @@ namespace AccountingSystem.Controllers
                     Balance = g.Sum(n => n.Balance),
                     BalanceSelected = g.Sum(n => n.BalanceSelected),
                     BalanceBase = g.Sum(n => n.BalanceBase),
-                    Children = g.OrderBy(n => n.Code).ToList(),
-                    HasChildren = g.Any()
-                }).ToList();
+                    HasChildren = g.Any(),
+                    Children = new List<AccountTreeNodeViewModel>()
+                })
+                .ToList();
 
-            var totals = accountTypeTrees.ToDictionary(n => n.AccountType, n => (n.BalanceSelected, n.BalanceBase));
+            decimal GetTotal(AccountType type, bool isBase)
+            {
+                return treeData.TotalsByType.TryGetValue(type, out var totals)
+                    ? (isBase ? totals.Base : totals.Selected)
+                    : 0m;
+            }
 
             var viewModel = new DashboardViewModel
             {
                 SelectedBranchId = branchId,
-                SelectedCurrencyId = selectedCurrency.Id,
-                SelectedCurrencyCode = selectedCurrency.Code,
-                BaseCurrencyCode = baseCurrency.Code,
-                FromDate = startDate,
-                ToDate = endDate,
-                TotalAssets = totals.ContainsKey(AccountType.Assets) ? totals[AccountType.Assets].Item1 : 0,
-                TotalLiabilities = totals.ContainsKey(AccountType.Liabilities) ? totals[AccountType.Liabilities].Item1 : 0,
-                TotalEquity = totals.ContainsKey(AccountType.Equity) ? totals[AccountType.Equity].Item1 : 0,
-                TotalRevenues = totals.ContainsKey(AccountType.Revenue) ? totals[AccountType.Revenue].Item1 : 0,
-                TotalExpenses = totals.ContainsKey(AccountType.Expenses) ? totals[AccountType.Expenses].Item1 : 0,
-                TotalAssetsBase = totals.ContainsKey(AccountType.Assets) ? totals[AccountType.Assets].Item2 : 0,
-                TotalLiabilitiesBase = totals.ContainsKey(AccountType.Liabilities) ? totals[AccountType.Liabilities].Item2 : 0,
-                TotalEquityBase = totals.ContainsKey(AccountType.Equity) ? totals[AccountType.Equity].Item2 : 0,
-                TotalRevenuesBase = totals.ContainsKey(AccountType.Revenue) ? totals[AccountType.Revenue].Item2 : 0,
-                TotalExpensesBase = totals.ContainsKey(AccountType.Expenses) ? totals[AccountType.Expenses].Item2 : 0,
+                SelectedCurrencyId = treeData.SelectedCurrency.Id,
+                SelectedCurrencyCode = treeData.SelectedCurrency.Code,
+                BaseCurrencyCode = treeData.BaseCurrency.Code,
+                FromDate = treeData.StartDate,
+                ToDate = treeData.EndDate,
+                TotalAssets = GetTotal(AccountType.Assets, false),
+                TotalLiabilities = GetTotal(AccountType.Liabilities, false),
+                TotalEquity = GetTotal(AccountType.Equity, false),
+                TotalRevenues = GetTotal(AccountType.Revenue, false),
+                TotalExpenses = GetTotal(AccountType.Expenses, false),
+                TotalAssetsBase = GetTotal(AccountType.Assets, true),
+                TotalLiabilitiesBase = GetTotal(AccountType.Liabilities, true),
+                TotalEquityBase = GetTotal(AccountType.Equity, true),
+                TotalRevenuesBase = GetTotal(AccountType.Revenue, true),
+                TotalExpensesBase = GetTotal(AccountType.Expenses, true),
                 AccountTypeTrees = accountTypeTrees,
-                CashBoxes = cashBoxes
+                CashBoxes = treeData.CashBoxes
             };
 
             viewModel.NetIncome = viewModel.TotalRevenues - viewModel.TotalExpenses;
@@ -177,6 +101,77 @@ namespace AccountingSystem.Controllers
         }
 
         [HttpGet]
+        public async Task<IActionResult> LoadAccountTreeNodes(AccountType? accountType, int? parentId = null, int? branchId = null, DateTime? fromDate = null, DateTime? toDate = null, int? currencyId = null)
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            var userBranchIds = await _context.UserBranches
+                .Where(ub => ub.UserId == userId)
+                .Select(ub => ub.BranchId)
+                .ToListAsync();
+
+            if (branchId.HasValue && !userBranchIds.Contains(branchId.Value))
+            {
+                branchId = null;
+            }
+
+            var treeData = await ComputeDashboardTreeAsync(userBranchIds, branchId, fromDate, toDate, currencyId);
+
+            IEnumerable<AccountTreeNodeViewModel> nodesToRender;
+
+            if (parentId.HasValue && parentId.Value > 0)
+            {
+                if (treeData.NodesById.TryGetValue(parentId.Value, out var parentNode))
+                {
+                    nodesToRender = parentNode.Children.OrderBy(n => n.Code);
+                }
+                else
+                {
+                    nodesToRender = Enumerable.Empty<AccountTreeNodeViewModel>();
+                }
+            }
+            else
+            {
+                if (!accountType.HasValue)
+                {
+                    nodesToRender = Enumerable.Empty<AccountTreeNodeViewModel>();
+                }
+                else
+                {
+                    nodesToRender = treeData.RootNodes
+                        .Where(n => n.AccountType == accountType.Value)
+                        .OrderBy(n => n.Code);
+                }
+            }
+
+            var sanitizedNodes = nodesToRender
+                .Select(n => new AccountTreeNodeViewModel
+                {
+                    Id = n.Id,
+                    Code = n.Code,
+                    NameAr = n.NameAr,
+                    AccountType = n.AccountType,
+                    Nature = n.Nature,
+                    CurrencyCode = n.CurrencyCode,
+                    OpeningBalance = n.OpeningBalance,
+                    Balance = n.Balance,
+                    BalanceSelected = n.BalanceSelected,
+                    BalanceBase = n.BalanceBase,
+                    IsActive = n.IsActive,
+                    CanPostTransactions = n.CanPostTransactions,
+                    ParentId = n.ParentId,
+                    Level = n.Level,
+                    HasChildren = n.Children.Any(),
+                    Children = new List<AccountTreeNodeViewModel>()
+                })
+                .ToList();
+
+            ViewData["SelectedCurrencyCode"] = treeData.SelectedCurrency.Code;
+            ViewData["BaseCurrencyCode"] = treeData.BaseCurrency.Code;
+
+            return PartialView("~/Views/Shared/_AccountBalanceTreeNode.cshtml", sanitizedNodes);
+        }
+
+        [HttpGet]
         public async Task<IActionResult> GetBranches()
         {
             var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
@@ -186,6 +181,139 @@ namespace AccountingSystem.Controllers
                 .ToListAsync();
 
             return Json(branches);
+        }
+
+        private async Task<DashboardTreeComputationResult> ComputeDashboardTreeAsync(List<int> userBranchIds, int? branchId, DateTime? fromDate, DateTime? toDate, int? currencyId)
+        {
+            var effectiveBranchId = branchId.HasValue && userBranchIds.Contains(branchId.Value)
+                ? branchId
+                : null;
+
+            var allowedBranchIds = effectiveBranchId.HasValue ? new List<int> { effectiveBranchId.Value } : userBranchIds;
+
+            var startDate = fromDate?.Date ?? DateTime.Today;
+            var toDateValue = toDate?.Date ?? DateTime.Today;
+            var endDate = toDateValue.Date.AddDays(1).AddTicks(-1);
+
+            var accounts = await _context.Accounts
+                .Where(a => !allowedBranchIds.Any() || a.BranchId == null || allowedBranchIds.Contains(a.BranchId.Value))
+                .Include(a => a.Branch)
+                .Include(a => a.JournalEntryLines)
+                    .ThenInclude(l => l.JournalEntry)
+                .Include(a => a.Currency)
+                .AsNoTracking()
+                .ToListAsync();
+
+            var baseCurrency = await _context.Currencies.FirstAsync(c => c.IsBase);
+            var selectedCurrency = currencyId.HasValue
+                ? await _context.Currencies.FirstOrDefaultAsync(c => c.Id == currencyId.Value)
+                : baseCurrency;
+            selectedCurrency ??= baseCurrency;
+
+            var accountBalances = accounts.ToDictionary(a => a.Id, a =>
+                a.OpeningBalance + a.JournalEntryLines
+                    .Where(l => l.JournalEntry.Date >= startDate && l.JournalEntry.Date <= endDate && allowedBranchIds.Contains(l.JournalEntry.BranchId))
+                    .Sum(l => l.DebitAmount - l.CreditAmount));
+
+            var cashBoxes = accounts
+                .Where(a => a.Code.StartsWith("1101"))
+                .Select(a =>
+                {
+                    var balance = accountBalances[a.Id];
+                    return new CashBoxBalanceViewModel
+                    {
+                        AccountName = a.NameAr,
+                        BranchName = a.Branch?.NameAr ?? string.Empty,
+                        Balance = balance,
+                        BalanceSelected = _currencyService.Convert(balance, a.Currency, selectedCurrency),
+                        BalanceBase = _currencyService.Convert(balance, a.Currency, baseCurrency)
+                    };
+                })
+                .ToList();
+
+            var nodes = accounts.Select(a =>
+            {
+                var balance = accountBalances[a.Id];
+                return new AccountTreeNodeViewModel
+                {
+                    Id = a.Id,
+                    Code = a.Code,
+                    NameAr = a.NameAr,
+                    AccountType = a.AccountType,
+                    Nature = a.Nature,
+                    CurrencyCode = a.Currency.Code,
+                    OpeningBalance = a.OpeningBalance,
+                    Balance = balance,
+                    BalanceSelected = _currencyService.Convert(balance, a.Currency, selectedCurrency),
+                    BalanceBase = _currencyService.Convert(balance, a.Currency, baseCurrency),
+                    IsActive = a.IsActive,
+                    CanPostTransactions = a.CanPostTransactions,
+                    ParentId = a.ParentId,
+                    Level = a.Level,
+                    Children = new List<AccountTreeNodeViewModel>(),
+                    HasChildren = false
+                };
+            }).ToDictionary(n => n.Id);
+
+            foreach (var node in nodes.Values)
+            {
+                if (node.ParentId.HasValue && nodes.TryGetValue(node.ParentId.Value, out var parent))
+                {
+                    parent.Children.Add(node);
+                    parent.HasChildren = true;
+                }
+            }
+
+            void ComputeBalances(AccountTreeNodeViewModel node)
+            {
+                foreach (var child in node.Children)
+                {
+                    ComputeBalances(child);
+                }
+
+                if (node.Children.Any())
+                {
+                    node.Balance = node.Children.Sum(c => c.Balance);
+                    node.BalanceSelected = node.Children.Sum(c => c.BalanceSelected);
+                    node.BalanceBase = node.Children.Sum(c => c.BalanceBase);
+                }
+            }
+
+            var rootNodes = nodes.Values.Where(n => n.ParentId == null).ToList();
+            foreach (var root in rootNodes)
+            {
+                ComputeBalances(root);
+            }
+
+            var totals = rootNodes
+                .GroupBy(n => n.AccountType)
+                .ToDictionary(g => g.Key, g => (
+                    Selected: g.Sum(n => n.BalanceSelected),
+                    Base: g.Sum(n => n.BalanceBase)));
+
+            return new DashboardTreeComputationResult
+            {
+                RootNodes = rootNodes,
+                NodesById = nodes,
+                TotalsByType = totals,
+                BaseCurrency = baseCurrency,
+                SelectedCurrency = selectedCurrency,
+                CashBoxes = cashBoxes,
+                StartDate = startDate,
+                EndDate = endDate
+            };
+        }
+
+        private class DashboardTreeComputationResult
+        {
+            public List<AccountTreeNodeViewModel> RootNodes { get; set; } = new List<AccountTreeNodeViewModel>();
+            public Dictionary<int, AccountTreeNodeViewModel> NodesById { get; set; } = new Dictionary<int, AccountTreeNodeViewModel>();
+            public Dictionary<AccountType, (decimal Selected, decimal Base)> TotalsByType { get; set; } = new Dictionary<AccountType, (decimal Selected, decimal Base)>();
+            public Currency BaseCurrency { get; set; } = null!;
+            public Currency SelectedCurrency { get; set; } = null!;
+            public List<CashBoxBalanceViewModel> CashBoxes { get; set; } = new List<CashBoxBalanceViewModel>();
+            public DateTime StartDate { get; set; }
+            public DateTime EndDate { get; set; }
         }
     }
 }

--- a/AccountingSystem/Views/Accounts/Tree.cshtml
+++ b/AccountingSystem/Views/Accounts/Tree.cshtml
@@ -130,20 +130,66 @@
     </div>
     <script>
         $(document).ready(function () {
-            $('.toggle-btn').click(function () {
-                var $this = $(this);
-                var $children = $this.closest('.tree-node').find('> .tree-children');
+            var loadUrl = '@Url.Action("LoadTreeNodes")';
 
-                if ($children.is(':visible')) {
-                    $children.hide();
-                    $this.html('<i class="fas fa-plus"></i>');
-                } else {
-                    $children.show();
-                    $this.html('<i class="fas fa-minus"></i>');
+            $(document).on('click', '.toggle-btn', function () {
+                var $button = $(this);
+                var $node = $button.closest('.tree-node');
+                var hasChildren = $node.data('has-children');
+
+                if (!hasChildren) {
+                    return;
                 }
-            });
 
-            $('.tree-node[data-level="0"] .toggle-btn').click();
+                var $children = $node.find('> .tree-children');
+                var isVisible = $children.is(':visible');
+
+                if (isVisible) {
+                    $children.slideUp(200);
+                    $button.html('<i class="fas fa-plus"></i>');
+                    return;
+                }
+
+                if ($children.data('loaded')) {
+                    $children.slideDown(200);
+                    $button.html('<i class="fas fa-minus"></i>');
+                    return;
+                }
+
+                var nodeId = parseInt($node.data('node-id')) || 0;
+                var accountType = $node.data('account-type');
+                var requestData = {};
+
+                if (nodeId > 0) {
+                    requestData.parentId = nodeId;
+                } else if (accountType) {
+                    requestData.accountType = accountType;
+                }
+
+                $button.prop('disabled', true).html('<i class="fas fa-spinner fa-spin"></i>');
+
+                $.get(loadUrl, requestData)
+                    .done(function (html) {
+                        var trimmed = $.trim(html);
+                        if (trimmed.length) {
+                            $children.html(trimmed);
+                            $children.data('loaded', true);
+                            $children.slideDown(200);
+                            $button.html('<i class="fas fa-minus"></i>');
+                        } else {
+                            $children.data('loaded', true);
+                            $node.data('has-children', false);
+                            $button.replaceWith('<span style="width: 20px; display: inline-block;"></span>');
+                        }
+                    })
+                    .fail(function () {
+                        alert('تعذر تحميل بيانات الحسابات، يرجى المحاولة مرة أخرى.');
+                        $button.html('<i class="fas fa-plus"></i>');
+                    })
+                    .always(function () {
+                        $button.prop('disabled', false);
+                    });
+            });
 
             $(document).on('click', '.ajax-modal', function (e) {
                 e.preventDefault();

--- a/AccountingSystem/Views/Accounts/_AccountTreeNode.cshtml
+++ b/AccountingSystem/Views/Accounts/_AccountTreeNode.cshtml
@@ -2,13 +2,17 @@
 
 @foreach (var node in Model)
 {
-    <div class="tree-node level-@node.Level" data-level="@node.Level">
+    var hasChildren = node.HasChildren;
+    var hasPreloadedChildren = node.Children.Any();
+    var containerDisplay = hasPreloadedChildren ? "block" : "none";
+    var toggleIcon = hasPreloadedChildren ? "minus" : "plus";
+    <div class="tree-node level-@node.Level" data-level="@node.Level" data-node-id="@node.Id" data-account-type="@(node.Id == 0 ? node.AccountType.ToString() : string.Empty)" data-has-children="@(hasChildren.ToString().ToLower())">
         <div class="tree-node-content">
             <div class="tree-node-info">
-                @if (node.Children.Any())
+                @if (hasChildren)
                 {
-                    <button class="toggle-btn" type="button">
-                        <i class="fas fa-minus"></i>
+                    <button class="toggle-btn" type="button" data-loaded="@(hasPreloadedChildren.ToString().ToLower())">
+                        <i class="fas fa-@toggleIcon"></i>
                     </button>
                 }
                 else
@@ -75,10 +79,13 @@
             }
         </div>
 
-        @if (node.Children.Any())
+        @if (hasChildren)
         {
-            <div class="tree-children">
-                @await Html.PartialAsync("_AccountTreeNode", node.Children)
+            <div class="tree-children" data-loaded="@(hasPreloadedChildren.ToString().ToLower())" style="display:@containerDisplay">
+                @if (hasPreloadedChildren)
+                {
+                    @await Html.PartialAsync("_AccountTreeNode", node.Children)
+                }
             </div>
         }
     </div>

--- a/AccountingSystem/Views/Dashboard/Index.cshtml
+++ b/AccountingSystem/Views/Dashboard/Index.cshtml
@@ -301,7 +301,13 @@
                             <div class="card-body">
                                 @if (Model.AccountTypeTrees.Any())
                                 {
-                                    <div class="tree-container">
+                                    <div id="dashboardAccountsTree" class="tree-container"
+                                         data-branch-id="@(Model.SelectedBranchId?.ToString() ?? string.Empty)"
+                                         data-from-date="@Model.FromDate.ToString("yyyy-MM-dd")"
+                                         data-to-date="@Model.ToDate.ToString("yyyy-MM-dd")"
+                                         data-currency-id="@(Model.SelectedCurrencyId?.ToString() ?? string.Empty)"
+                                         data-selected-currency="@Model.SelectedCurrencyCode"
+                                         data-base-currency="@Model.BaseCurrencyCode">
                                         @{
                                             ViewData["SelectedCurrencyCode"] = Model.SelectedCurrencyCode; ViewData["BaseCurrencyCode"] = Model.BaseCurrencyCode;
                                         }
@@ -1026,19 +1032,87 @@
                 });
             });
 
-            $('.toggle-btn').on('click', function () {
-                var $this = $(this);
-                var $children = $this.closest('.tree-node').find('> .tree-children');
-                if ($children.is(':visible')) {
-                    $children.hide();
-                    $this.html('<i class="fas fa-plus"></i>');
-                } else {
-                    $children.show();
-                    $this.html('<i class="fas fa-minus"></i>');
-                }
-            });
+            var $accountsTree = $('#dashboardAccountsTree');
+            var loadTreeUrl = '@Url.Action("LoadAccountTreeNodes")';
 
-            $('.tree-node[data-level="0"] .toggle-btn').trigger('click');
+            $(document).on('click', '#dashboardAccountsTree .toggle-btn', function () {
+                var $button = $(this);
+                var $node = $button.closest('.tree-node');
+                var hasChildren = $node.data('has-children');
+
+                if (!hasChildren) {
+                    return;
+                }
+
+                var $children = $node.find('> .tree-children');
+                var isVisible = $children.is(':visible');
+
+                if (isVisible) {
+                    $children.slideUp(200);
+                    $button.html('<i class="fas fa-plus"></i>');
+                    return;
+                }
+
+                if ($children.data('loaded')) {
+                    $children.slideDown(200);
+                    $button.html('<i class="fas fa-minus"></i>');
+                    return;
+                }
+
+                var nodeId = parseInt($node.data('node-id')) || 0;
+                var accountType = $node.data('account-type');
+                var requestData = {};
+
+                if (nodeId > 0) {
+                    requestData.parentId = nodeId;
+                }
+
+                if (accountType) {
+                    requestData.accountType = accountType;
+                }
+
+                var branchId = $accountsTree.data('branch-id');
+                var fromDate = $accountsTree.data('from-date');
+                var toDate = $accountsTree.data('to-date');
+                var currencyId = $accountsTree.data('currency-id');
+
+                if (branchId) {
+                    requestData.branchId = branchId;
+                }
+                if (fromDate) {
+                    requestData.fromDate = fromDate;
+                }
+                if (toDate) {
+                    requestData.toDate = toDate;
+                }
+                if (currencyId) {
+                    requestData.currencyId = currencyId;
+                }
+
+                $button.prop('disabled', true).html('<i class="fas fa-spinner fa-spin"></i>');
+
+                $.get(loadTreeUrl, requestData)
+                    .done(function (html) {
+                        var trimmed = $.trim(html);
+                        if (trimmed.length) {
+                            $children.html(trimmed);
+                            $children.data('loaded', true);
+                            $children.slideDown(200);
+                            $button.html('<i class="fas fa-minus"></i>');
+                        } else {
+                            $children.data('loaded', true);
+                            $node.data('has-children', false);
+                            $button.replaceWith('<span style="width: 20px; display: inline-block;"></span>');
+                        }
+                    })
+                    .fail(function () {
+                        alert('تعذر تحميل بيانات الشجرة، يرجى المحاولة مرة أخرى.');
+                        $button.html('<i class="fas fa-plus"></i>');
+                    })
+                    .always(function () {
+                        $button.prop('disabled', false);
+                    });
+            });
         });
     </script>
 }

--- a/AccountingSystem/Views/Shared/_AccountBalanceTreeNode.cshtml
+++ b/AccountingSystem/Views/Shared/_AccountBalanceTreeNode.cshtml
@@ -2,13 +2,17 @@
 
 @foreach (var node in Model)
 {
-    <div class="tree-node level-@node.Level" data-level="@node.Level">
+    var hasChildren = node.HasChildren;
+    var hasPreloadedChildren = node.Children.Any();
+    var containerDisplay = hasPreloadedChildren ? "block" : "none";
+    var toggleIcon = hasPreloadedChildren ? "minus" : "plus";
+    <div class="tree-node level-@node.Level" data-level="@node.Level" data-node-id="@node.Id" data-account-type="@(node.Id == 0 ? node.AccountType.ToString() : string.Empty)" data-has-children="@(hasChildren.ToString().ToLower())">
         <div class="tree-node-content">
             <div class="tree-node-info">
-                @if (node.Children.Any())
+                @if (hasChildren)
                 {
-                    <button class="toggle-btn" type="button">
-                        <i class="fas fa-minus"></i>
+                    <button class="toggle-btn" type="button" data-loaded="@(hasPreloadedChildren.ToString().ToLower())">
+                        <i class="fas fa-@toggleIcon"></i>
                     </button>
                 }
                 else
@@ -38,10 +42,13 @@
             </div>
         </div>
 
-        @if (node.Children.Any())
+        @if (hasChildren)
         {
-            <div class="tree-children">
-                @await Html.PartialAsync("_AccountBalanceTreeNode", node.Children)
+            <div class="tree-children" data-loaded="@(hasPreloadedChildren.ToString().ToLower())" style="display:@containerDisplay">
+                @if (hasPreloadedChildren)
+                {
+                    @await Html.PartialAsync("_AccountBalanceTreeNode", node.Children)
+                }
             </div>
         }
     </div>


### PR DESCRIPTION
## Summary
- load account tree roots lazily and add an endpoint to fetch child accounts on demand
- convert dashboard account balance tree to request nodes via AJAX with server-side filtering
- update shared tree partials and scripts to render placeholders and request children dynamically

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dc253248988333b398e5cb2a74cde9